### PR TITLE
Generate report

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,3 +11,5 @@ jobs:
     - uses: actions/checkout@v1
     - name: Run python-test-runner on example files
       run: sh run-in-docker.sh example test/
+    - name: Verify that results.json is created
+      run: test -f test/results.json && cat test/results.json

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,5 +3,6 @@ FROM python:3.7-alpine
 WORKDIR /opt/test-runner
 
 COPY ./run.sh ./bin/
+COPY ./process_results.py ./
 
 ENTRYPOINT [ "sh", "/opt/test-runner/bin/run.sh" ]

--- a/process_results.py
+++ b/process_results.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python
+import argparse
+import json
+from pathlib import Path
+import xml.etree.ElementTree as ET
+
+
+def _process_xml_tree(tree):
+    results = {
+        'status': 'pass',
+        'message': None,
+        'tests': []
+    }
+    root = tree.getroot()
+    for testcase in root.findall('*/testcase'):
+        case = {
+            'name': testcase.attrib['name'],
+            'status': 'pass'
+        }
+        error = testcase.find('./error')
+        failure = testcase.find('./failure')
+        if error is not None:
+            results['status'] = 'error'
+            case['status'] = 'error'
+            case['message'] = error.attrib['message']
+        elif failure is not None:
+            # Don't allow subsequent failures to clobber error status
+            if results['status'] != 'error':
+                results['status'] = 'fail'
+            case['status'] = 'fail'
+            case['message'] = failure.attrib['message']
+        results['tests'].append(case)
+    return results
+
+
+def _write_output_file(results, output_path):
+    if output_path == '-':
+        print(json.dumps(results, indent=2))
+    else:
+        with open(output_path, 'w') as f:
+            f.write(json.dumps(results))
+
+
+def convert_junitxml_to_json(xml_path, output_path):
+    tree = ET.parse(xml_path)
+    results = _process_xml_tree(tree)
+    _write_output_file(results, output_path)
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser()
+    parser.add_argument('xml_path', type=Path, help='JUnit XML report file')
+    parser.add_argument(
+        'output_path',
+        nargs='?',
+        default='-',
+        help='JSON output path'
+    )
+    opts = parser.parse_args()
+    convert_junitxml_to_json(opts.xml_path, opts.output_path)

--- a/run-in-docker.sh
+++ b/run-in-docker.sh
@@ -16,6 +16,12 @@
 # Example:
 # ./run-in-docker.sh two-fer ./relative/path/to/two-fer/solution/folder
 
+# If arguments not provided, print usage and exit
+if [ -z "$1" ] || [ -z "$2" ]; then
+    echo "usage: run-in-docker.sh exercise-slug ./relative/path/to/solution/folder"
+    exit 1
+fi
+
 # build docker image
 docker build -t python-test-runner .
 

--- a/run.sh
+++ b/run.sh
@@ -23,4 +23,10 @@ test_file="${1/-/_}"
 # Put together path to the test file
 test_file="$2/$test_file"_test.py
 
-pytest "$test_file"
+# Run pytest and generate JUnit xml report
+pytest --junitxml="results.xml" "$test_file"
+
+# Convert JUnit report to results.json
+# At some future date, this script should be replaced
+# with one provided by exercism/automated-tests
+python process_results.py results.xml "$2/results.json"

--- a/test/example.py
+++ b/test/example.py
@@ -1,3 +1,4 @@
 """Example Exercism/Python solution file"""
+
 def hello():
     return 'Hello, World!'


### PR DESCRIPTION
Per instruction from exercism/automated-tests#14 (about to be merged), the runner should create a `results.json` file in the solution directory.

Note that the new `process_results.py` script is only necessary until exercism/automated-tests produced a JUnit to results.json converter script to be used globally.