### PR TITLE
Run CI on pull request

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,6 +2,13 @@
 name: CI
 
 on:
+  pull_request:
+    branches:
+      - master
+    paths-ignore:
+      - '.gitignore'
+      - 'LICENSE'
+      - '**.md'
   push:
     paths-ignore:
       - '.gitignore'


### PR DESCRIPTION
This change should resolve the issue we saw in #27 where a PR from a fork didn't trigger the CI job.