### PR TITLE
Using a cache_dir that's within /tmp storage

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,3 @@
 [pytest]
 norecursedirs = .git .github example* traceback-styles*
+cache_dir = /tmp/python_cache_dir


### PR DESCRIPTION
Since /opt/test-runner is read-only in prod, this tweak allows pytest to use a different location for scratch storage.