### PR TITLE
[Docker] Fix entry point

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,4 +8,4 @@ COPY . /opt/test-runner
 
 WORKDIR /opt/test-runner
 
-ENTRYPOINT [ "sh", "/bin/run.sh" ]
+ENTRYPOINT [ "sh", "bin/run.sh" ]


### PR DESCRIPTION
Currently, the Docker image does not run succesfully:

```
sh: can't open '/bin/run.sh': No such file or directory
```

The entrypoint's path is wrong, which is fixed in this PR.