### PR TITLE
block pytest 5.4

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 # cmccandless: Breaking changes in pytest 5.4.0
 # Changelog: https://docs.pytest.org/en/stable/changelog.html#pytest-5-4-0-2020-03-12
-pytest>=5.3.1,<5.4.0
+pytest>=5.3.1,!=5.4.0


### PR DESCRIPTION
Changes to output format were made in pytest 5.4, but reverted in 6.0. Blocking 5.4 should be sufficient for our tests to pass.