### PR TITLE
[Fix #69] Testcode Extraction

### DIFF
--- a/test/example-all-fail-tasks-and-subtests/example_all_fail_tasks_and_subtests.py
+++ b/test/example-all-fail-tasks-and-subtests/example_all_fail_tasks_and_subtests.py
@@ -1,0 +1,5 @@
+"""Example Exercism/Python solution file"""
+
+
+def hello(param):
+    return "Goodbye!"

--- a/test/example-all-fail-tasks-and-subtests/example_all_fail_tasks_and_subtests_test.py
+++ b/test/example-all-fail-tasks-and-subtests/example_all_fail_tasks_and_subtests_test.py
@@ -1,0 +1,59 @@
+import unittest
+import pytest
+
+
+from example_all_fail_tasks_and_subtests import hello
+
+
+class ExampleAllFailTest(unittest.TestCase):
+
+    @pytest.mark.task(taskno=1)
+    def test_hello(self):
+        input_data = [15, 23, 33, 39]
+        result_data = [("Hello, World!", param) for param in input_data]
+        number_of_variants = range(1, len(input_data) + 1)
+
+        for variant, param, result in zip(number_of_variants, input_data, result_data):
+            with self.subTest(f"variation #{variant}", param=param, result=result):
+                self.assertEqual(hello(param), result,
+                                 msg=f'Expected: {result} but got something else instead.')
+
+    @pytest.mark.task(taskno=1)
+    def test_abc(self):
+        input_data = ['frog', 'fish', 'coconut', 'pineapple', 'carrot', 'cucumber', 'grass', 'tree']
+        result_data = [("Hello, World!", param) for param in input_data]
+        number_of_variants = range(1, len(input_data) + 1)
+
+        for variant, param, result in zip(number_of_variants, input_data, result_data):
+            with self.subTest(f"variation #{variant}", param=param, result=result):
+                self.assertEqual(hello(param), result,
+                                 msg=f'Expected: {result} but got something else instead.')
+
+
+class ExampleAllFailOtherTest(unittest.TestCase):
+
+    @pytest.mark.task(taskno=2)
+    def test_dummy(self):
+        input_data = ['frog', 'fish', 'coconut', 'pineapple', 'carrot', 'cucumber', 'grass', 'tree']
+        result_data = [("Hello, World!", param) for param in input_data]
+        number_of_variants = range(1, len(input_data) + 1)
+
+        for variant, param, result in zip(number_of_variants, input_data, result_data):
+            with self.subTest(f"variation #{variant}", param=param, result=result):
+                self.assertEqual(hello(param), result,
+                                 msg=f'Expected: {result} but got something else instead.')
+
+    @pytest.mark.task(taskno=2)
+    def test_hello(self):
+        input_data = [1, 2, 5, 10]
+        result_data = [("Hello, World!", param) for param in input_data]
+        number_of_variants = range(1, len(input_data) + 1)
+
+        for variant, param, result in zip(number_of_variants, input_data, result_data):
+            with self.subTest(f"variation #{variant}", param=param, result=result):
+                self.assertEqual(hello(param), result,
+                                 msg=f'Expected: {result} but got something else instead.')
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/example-all-fail-tasks-and-subtests/results.json
+++ b/test/example-all-fail-tasks-and-subtests/results.json
@@ -1,0 +1,202 @@
+{
+  "version": 3,
+  "status": "fail",
+  "tests": [
+    {
+      "name": "ExampleAllFailTest.test_abc",
+      "status": "fail",
+      "message": "One or more subtests for this test failed. Details can be found under each variant.",
+      "test_code": "input_data = ['frog', 'fish', 'coconut', 'pineapple', 'carrot', 'cucumber', 'grass', 'tree']\nresult_data = [(\"Hello, World!\", param) for param in input_data]\nnumber_of_variants = range(1, len(input_data) + 1)\n\nfor variant, param, result in zip(number_of_variants, input_data, result_data):\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result,\n                         msg=f'Expected: {result} but got something else instead.')",
+      "task_id": 1
+    },
+    {
+      "name": "ExampleAllFailTest.test_hello",
+      "status": "fail",
+      "message": "One or more subtests for this test failed. Details can be found under each variant.",
+      "test_code": "input_data = [15, 23, 33, 39]\nresult_data = [(\"Hello, World!\", param) for param in input_data]\nnumber_of_variants = range(1, len(input_data) + 1)\n\nfor variant, param, result in zip(number_of_variants, input_data, result_data):\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result,\n                         msg=f'Expected: {result} but got something else instead.')",
+      "task_id": 1
+    },
+    {
+      "name": "ExampleAllFailOtherTest.test_dummy",
+      "status": "fail",
+      "message": "One or more subtests for this test failed. Details can be found under each variant.",
+      "test_code": "input_data = ['frog', 'fish', 'coconut', 'pineapple', 'carrot', 'cucumber', 'grass', 'tree']\nresult_data = [(\"Hello, World!\", param) for param in input_data]\nnumber_of_variants = range(1, len(input_data) + 1)\n\nfor variant, param, result in zip(number_of_variants, input_data, result_data):\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result,\n                         msg=f'Expected: {result} but got something else instead.')",
+      "task_id": 2
+    },
+    {
+      "name": "ExampleAllFailOtherTest.test_hello",
+      "status": "fail",
+      "message": "One or more subtests for this test failed. Details can be found under each variant.",
+      "test_code": "input_data = [1, 2, 5, 10]\nresult_data = [(\"Hello, World!\", param) for param in input_data]\nnumber_of_variants = range(1, len(input_data) + 1)\n\nfor variant, param, result in zip(number_of_variants, input_data, result_data):\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result,\n                         msg=f'Expected: {result} but got something else instead.')",
+      "task_id": 2
+    },
+    {
+      "name": "ExampleAllFailTest.test_hello [variation #1] (param=15, result=('Hello, World!', 15))",
+      "status": "fail",
+      "message": "AssertionError: 'Goodbye!' != ('Hello, World!', 15) : Expected: ('Hello, World!', 15) but got something else instead.",
+      "test_code": "input_data = [15, 23, 33, 39]\nresult_data = [(\"Hello, World!\", param) for param in input_data]\nnumber_of_variants = range(1, len(input_data) + 1)\n\nfor variant, param, result in zip(number_of_variants, input_data, result_data):\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result,\n                         msg=f'Expected: {result} but got something else instead.')",
+      "task_id": 1
+    },
+    {
+      "name": "ExampleAllFailTest.test_hello [variation #2] (param=23, result=('Hello, World!', 23))",
+      "status": "fail",
+      "message": "AssertionError: 'Goodbye!' != ('Hello, World!', 23) : Expected: ('Hello, World!', 23) but got something else instead.",
+      "test_code": "input_data = [15, 23, 33, 39]\nresult_data = [(\"Hello, World!\", param) for param in input_data]\nnumber_of_variants = range(1, len(input_data) + 1)\n\nfor variant, param, result in zip(number_of_variants, input_data, result_data):\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result,\n                         msg=f'Expected: {result} but got something else instead.')",
+      "task_id": 1
+    },
+    {
+      "name": "ExampleAllFailTest.test_hello [variation #3] (param=33, result=('Hello, World!', 33))",
+      "status": "fail",
+      "message": "AssertionError: 'Goodbye!' != ('Hello, World!', 33) : Expected: ('Hello, World!', 33) but got something else instead.",
+      "test_code": "input_data = [15, 23, 33, 39]\nresult_data = [(\"Hello, World!\", param) for param in input_data]\nnumber_of_variants = range(1, len(input_data) + 1)\n\nfor variant, param, result in zip(number_of_variants, input_data, result_data):\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result,\n                         msg=f'Expected: {result} but got something else instead.')",
+      "task_id": 1
+    },
+    {
+      "name": "ExampleAllFailTest.test_hello [variation #4] (param=39, result=('Hello, World!', 39))",
+      "status": "fail",
+      "message": "AssertionError: 'Goodbye!' != ('Hello, World!', 39) : Expected: ('Hello, World!', 39) but got something else instead.",
+      "test_code": "input_data = [15, 23, 33, 39]\nresult_data = [(\"Hello, World!\", param) for param in input_data]\nnumber_of_variants = range(1, len(input_data) + 1)\n\nfor variant, param, result in zip(number_of_variants, input_data, result_data):\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result,\n                         msg=f'Expected: {result} but got something else instead.')",
+      "task_id": 1
+    },
+    {
+      "name": "ExampleAllFailTest.test_abc [variation #1] (param='frog', result=('Hello, World!', 'frog'))",
+      "status": "fail",
+      "message": "AssertionError: 'Goodbye!' != ('Hello, World!', 'frog') : Expected: ('Hello, World!', 'frog') but got something else instead.",
+      "test_code": "input_data = ['frog', 'fish', 'coconut', 'pineapple', 'carrot', 'cucumber', 'grass', 'tree']\nresult_data = [(\"Hello, World!\", param) for param in input_data]\nnumber_of_variants = range(1, len(input_data) + 1)\n\nfor variant, param, result in zip(number_of_variants, input_data, result_data):\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result,\n                         msg=f'Expected: {result} but got something else instead.')",
+      "task_id": 1
+    },
+    {
+      "name": "ExampleAllFailTest.test_abc [variation #2] (param='fish', result=('Hello, World!', 'fish'))",
+      "status": "fail",
+      "message": "AssertionError: 'Goodbye!' != ('Hello, World!', 'fish') : Expected: ('Hello, World!', 'fish') but got something else instead.",
+      "test_code": "input_data = ['frog', 'fish', 'coconut', 'pineapple', 'carrot', 'cucumber', 'grass', 'tree']\nresult_data = [(\"Hello, World!\", param) for param in input_data]\nnumber_of_variants = range(1, len(input_data) + 1)\n\nfor variant, param, result in zip(number_of_variants, input_data, result_data):\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result,\n                         msg=f'Expected: {result} but got something else instead.')",
+      "task_id": 1
+    },
+    {
+      "name": "ExampleAllFailTest.test_abc [variation #3] (param='coconut', result=('Hello, World!', 'coconut'))",
+      "status": "fail",
+      "message": "AssertionError: 'Goodbye!' != ('Hello, World!', 'coconut') : Expected: ('Hello, World!', 'coconut') but got something else instead.",
+      "test_code": "input_data = ['frog', 'fish', 'coconut', 'pineapple', 'carrot', 'cucumber', 'grass', 'tree']\nresult_data = [(\"Hello, World!\", param) for param in input_data]\nnumber_of_variants = range(1, len(input_data) + 1)\n\nfor variant, param, result in zip(number_of_variants, input_data, result_data):\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result,\n                         msg=f'Expected: {result} but got something else instead.')",
+      "task_id": 1
+    },
+    {
+      "name": "ExampleAllFailTest.test_abc [variation #4] (param='pineapple', result=('Hello, World!', 'pineapple'))",
+      "status": "fail",
+      "message": "AssertionError: 'Goodbye!' != ('Hello, World!', 'pineapple') : Expected: ('Hello, World!', 'pineapple') but got something else instead.",
+      "test_code": "input_data = ['frog', 'fish', 'coconut', 'pineapple', 'carrot', 'cucumber', 'grass', 'tree']\nresult_data = [(\"Hello, World!\", param) for param in input_data]\nnumber_of_variants = range(1, len(input_data) + 1)\n\nfor variant, param, result in zip(number_of_variants, input_data, result_data):\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result,\n                         msg=f'Expected: {result} but got something else instead.')",
+      "task_id": 1
+    },
+    {
+      "name": "ExampleAllFailTest.test_abc [variation #5] (param='carrot', result=('Hello, World!', 'carrot'))",
+      "status": "fail",
+      "message": "AssertionError: 'Goodbye!' != ('Hello, World!', 'carrot') : Expected: ('Hello, World!', 'carrot') but got something else instead.",
+      "test_code": "input_data = ['frog', 'fish', 'coconut', 'pineapple', 'carrot', 'cucumber', 'grass', 'tree']\nresult_data = [(\"Hello, World!\", param) for param in input_data]\nnumber_of_variants = range(1, len(input_data) + 1)\n\nfor variant, param, result in zip(number_of_variants, input_data, result_data):\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result,\n                         msg=f'Expected: {result} but got something else instead.')",
+      "task_id": 1
+    },
+    {
+      "name": "ExampleAllFailTest.test_abc [variation #6] (param='cucumber', result=('Hello, World!', 'cucumber'))",
+      "status": "fail",
+      "message": "AssertionError: 'Goodbye!' != ('Hello, World!', 'cucumber') : Expected: ('Hello, World!', 'cucumber') but got something else instead.",
+      "test_code": "input_data = ['frog', 'fish', 'coconut', 'pineapple', 'carrot', 'cucumber', 'grass', 'tree']\nresult_data = [(\"Hello, World!\", param) for param in input_data]\nnumber_of_variants = range(1, len(input_data) + 1)\n\nfor variant, param, result in zip(number_of_variants, input_data, result_data):\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result,\n                         msg=f'Expected: {result} but got something else instead.')",
+      "task_id": 1
+    },
+    {
+      "name": "ExampleAllFailTest.test_abc [variation #7] (param='grass', result=('Hello, World!', 'grass'))",
+      "status": "fail",
+      "message": "AssertionError: 'Goodbye!' != ('Hello, World!', 'grass') : Expected: ('Hello, World!', 'grass') but got something else instead.",
+      "test_code": "input_data = ['frog', 'fish', 'coconut', 'pineapple', 'carrot', 'cucumber', 'grass', 'tree']\nresult_data = [(\"Hello, World!\", param) for param in input_data]\nnumber_of_variants = range(1, len(input_data) + 1)\n\nfor variant, param, result in zip(number_of_variants, input_data, result_data):\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result,\n                         msg=f'Expected: {result} but got something else instead.')",
+      "task_id": 1
+    },
+    {
+      "name": "ExampleAllFailTest.test_abc [variation #8] (param='tree', result=('Hello, World!', 'tree'))",
+      "status": "fail",
+      "message": "AssertionError: 'Goodbye!' != ('Hello, World!', 'tree') : Expected: ('Hello, World!', 'tree') but got something else instead.",
+      "test_code": "input_data = ['frog', 'fish', 'coconut', 'pineapple', 'carrot', 'cucumber', 'grass', 'tree']\nresult_data = [(\"Hello, World!\", param) for param in input_data]\nnumber_of_variants = range(1, len(input_data) + 1)\n\nfor variant, param, result in zip(number_of_variants, input_data, result_data):\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result,\n                         msg=f'Expected: {result} but got something else instead.')",
+      "task_id": 1
+    },
+    {
+      "name": "ExampleAllFailOtherTest.test_dummy [variation #1] (param='frog', result=('Hello, World!', 'frog'))",
+      "status": "fail",
+      "message": "AssertionError: 'Goodbye!' != ('Hello, World!', 'frog') : Expected: ('Hello, World!', 'frog') but got something else instead.",
+      "test_code": "input_data = ['frog', 'fish', 'coconut', 'pineapple', 'carrot', 'cucumber', 'grass', 'tree']\nresult_data = [(\"Hello, World!\", param) for param in input_data]\nnumber_of_variants = range(1, len(input_data) + 1)\n\nfor variant, param, result in zip(number_of_variants, input_data, result_data):\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result,\n                         msg=f'Expected: {result} but got something else instead.')",
+      "task_id": 2
+    },
+    {
+      "name": "ExampleAllFailOtherTest.test_dummy [variation #2] (param='fish', result=('Hello, World!', 'fish'))",
+      "status": "fail",
+      "message": "AssertionError: 'Goodbye!' != ('Hello, World!', 'fish') : Expected: ('Hello, World!', 'fish') but got something else instead.",
+      "test_code": "input_data = ['frog', 'fish', 'coconut', 'pineapple', 'carrot', 'cucumber', 'grass', 'tree']\nresult_data = [(\"Hello, World!\", param) for param in input_data]\nnumber_of_variants = range(1, len(input_data) + 1)\n\nfor variant, param, result in zip(number_of_variants, input_data, result_data):\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result,\n                         msg=f'Expected: {result} but got something else instead.')",
+      "task_id": 2
+    },
+    {
+      "name": "ExampleAllFailOtherTest.test_dummy [variation #3] (param='coconut', result=('Hello, World!', 'coconut'))",
+      "status": "fail",
+      "message": "AssertionError: 'Goodbye!' != ('Hello, World!', 'coconut') : Expected: ('Hello, World!', 'coconut') but got something else instead.",
+      "test_code": "input_data = ['frog', 'fish', 'coconut', 'pineapple', 'carrot', 'cucumber', 'grass', 'tree']\nresult_data = [(\"Hello, World!\", param) for param in input_data]\nnumber_of_variants = range(1, len(input_data) + 1)\n\nfor variant, param, result in zip(number_of_variants, input_data, result_data):\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result,\n                         msg=f'Expected: {result} but got something else instead.')",
+      "task_id": 2
+    },
+    {
+      "name": "ExampleAllFailOtherTest.test_dummy [variation #4] (param='pineapple', result=('Hello, World!', 'pineapple'))",
+      "status": "fail",
+      "message": "AssertionError: 'Goodbye!' != ('Hello, World!', 'pineapple') : Expected: ('Hello, World!', 'pineapple') but got something else instead.",
+      "test_code": "input_data = ['frog', 'fish', 'coconut', 'pineapple', 'carrot', 'cucumber', 'grass', 'tree']\nresult_data = [(\"Hello, World!\", param) for param in input_data]\nnumber_of_variants = range(1, len(input_data) + 1)\n\nfor variant, param, result in zip(number_of_variants, input_data, result_data):\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result,\n                         msg=f'Expected: {result} but got something else instead.')",
+      "task_id": 2
+    },
+    {
+      "name": "ExampleAllFailOtherTest.test_dummy [variation #5] (param='carrot', result=('Hello, World!', 'carrot'))",
+      "status": "fail",
+      "message": "AssertionError: 'Goodbye!' != ('Hello, World!', 'carrot') : Expected: ('Hello, World!', 'carrot') but got something else instead.",
+      "test_code": "input_data = ['frog', 'fish', 'coconut', 'pineapple', 'carrot', 'cucumber', 'grass', 'tree']\nresult_data = [(\"Hello, World!\", param) for param in input_data]\nnumber_of_variants = range(1, len(input_data) + 1)\n\nfor variant, param, result in zip(number_of_variants, input_data, result_data):\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result,\n                         msg=f'Expected: {result} but got something else instead.')",
+      "task_id": 2
+    },
+    {
+      "name": "ExampleAllFailOtherTest.test_dummy [variation #6] (param='cucumber', result=('Hello, World!', 'cucumber'))",
+      "status": "fail",
+      "message": "AssertionError: 'Goodbye!' != ('Hello, World!', 'cucumber') : Expected: ('Hello, World!', 'cucumber') but got something else instead.",
+      "test_code": "input_data = ['frog', 'fish', 'coconut', 'pineapple', 'carrot', 'cucumber', 'grass', 'tree']\nresult_data = [(\"Hello, World!\", param) for param in input_data]\nnumber_of_variants = range(1, len(input_data) + 1)\n\nfor variant, param, result in zip(number_of_variants, input_data, result_data):\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result,\n                         msg=f'Expected: {result} but got something else instead.')",
+      "task_id": 2
+    },
+    {
+      "name": "ExampleAllFailOtherTest.test_dummy [variation #7] (param='grass', result=('Hello, World!', 'grass'))",
+      "status": "fail",
+      "message": "AssertionError: 'Goodbye!' != ('Hello, World!', 'grass') : Expected: ('Hello, World!', 'grass') but got something else instead.",
+      "test_code": "input_data = ['frog', 'fish', 'coconut', 'pineapple', 'carrot', 'cucumber', 'grass', 'tree']\nresult_data = [(\"Hello, World!\", param) for param in input_data]\nnumber_of_variants = range(1, len(input_data) + 1)\n\nfor variant, param, result in zip(number_of_variants, input_data, result_data):\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result,\n                         msg=f'Expected: {result} but got something else instead.')",
+      "task_id": 2
+    },
+    {
+      "name": "ExampleAllFailOtherTest.test_dummy [variation #8] (param='tree', result=('Hello, World!', 'tree'))",
+      "status": "fail",
+      "message": "AssertionError: 'Goodbye!' != ('Hello, World!', 'tree') : Expected: ('Hello, World!', 'tree') but got something else instead.",
+      "test_code": "input_data = ['frog', 'fish', 'coconut', 'pineapple', 'carrot', 'cucumber', 'grass', 'tree']\nresult_data = [(\"Hello, World!\", param) for param in input_data]\nnumber_of_variants = range(1, len(input_data) + 1)\n\nfor variant, param, result in zip(number_of_variants, input_data, result_data):\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result,\n                         msg=f'Expected: {result} but got something else instead.')",
+      "task_id": 2
+    },
+    {
+      "name": "ExampleAllFailOtherTest.test_hello [variation #1] (param=1, result=('Hello, World!', 1))",
+      "status": "fail",
+      "message": "AssertionError: 'Goodbye!' != ('Hello, World!', 1) : Expected: ('Hello, World!', 1) but got something else instead.",
+      "test_code": "input_data = [1, 2, 5, 10]\nresult_data = [(\"Hello, World!\", param) for param in input_data]\nnumber_of_variants = range(1, len(input_data) + 1)\n\nfor variant, param, result in zip(number_of_variants, input_data, result_data):\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result,\n                         msg=f'Expected: {result} but got something else instead.')",
+      "task_id": 2
+    },
+    {
+      "name": "ExampleAllFailOtherTest.test_hello [variation #2] (param=2, result=('Hello, World!', 2))",
+      "status": "fail",
+      "message": "AssertionError: 'Goodbye!' != ('Hello, World!', 2) : Expected: ('Hello, World!', 2) but got something else instead.",
+      "test_code": "input_data = [1, 2, 5, 10]\nresult_data = [(\"Hello, World!\", param) for param in input_data]\nnumber_of_variants = range(1, len(input_data) + 1)\n\nfor variant, param, result in zip(number_of_variants, input_data, result_data):\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result,\n                         msg=f'Expected: {result} but got something else instead.')",
+      "task_id": 2
+    },
+    {
+      "name": "ExampleAllFailOtherTest.test_hello [variation #3] (param=5, result=('Hello, World!', 5))",
+      "status": "fail",
+      "message": "AssertionError: 'Goodbye!' != ('Hello, World!', 5) : Expected: ('Hello, World!', 5) but got something else instead.",
+      "test_code": "input_data = [1, 2, 5, 10]\nresult_data = [(\"Hello, World!\", param) for param in input_data]\nnumber_of_variants = range(1, len(input_data) + 1)\n\nfor variant, param, result in zip(number_of_variants, input_data, result_data):\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result,\n                         msg=f'Expected: {result} but got something else instead.')",
+      "task_id": 2
+    },
+    {
+      "name": "ExampleAllFailOtherTest.test_hello [variation #4] (param=10, result=('Hello, World!', 10))",
+      "status": "fail",
+      "message": "AssertionError: 'Goodbye!' != ('Hello, World!', 10) : Expected: ('Hello, World!', 10) but got something else instead.",
+      "test_code": "input_data = [1, 2, 5, 10]\nresult_data = [(\"Hello, World!\", param) for param in input_data]\nnumber_of_variants = range(1, len(input_data) + 1)\n\nfor variant, param, result in zip(number_of_variants, input_data, result_data):\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result,\n                         msg=f'Expected: {result} but got something else instead.')",
+      "task_id": 2
+    }
+  ]
+}

--- a/test/example-config-multiple-files-subtests-and-tasks/.meta/config.json
+++ b/test/example-config-multiple-files-subtests-and-tasks/.meta/config.json
@@ -1,0 +1,5 @@
+{
+    "files": {
+        "test": ["example_first_file_with_tasks_test.py", "example_second_file_with_tasks_and_subtests_test.py"]
+    }
+}

--- a/test/example-config-multiple-files-subtests-and-tasks/example_first_file_with_tasks_test.py
+++ b/test/example-config-multiple-files-subtests-and-tasks/example_first_file_with_tasks_test.py
@@ -1,0 +1,31 @@
+import unittest
+import pytest
+
+
+from example_with_config import hello
+
+
+class ExampleFirstTest(unittest.TestCase):
+
+    @pytest.mark.task(taskno=1)
+    def test_hello(self):
+        self.assertEqual(hello('Hi'), ("Hello, World!", 'Hi'))
+
+    @pytest.mark.task(taskno=1)
+    def test_abc(self):
+        self.assertEqual(hello(13), ("Hello, World!", 13))
+
+
+class ExampleFirstOtherTest(unittest.TestCase):
+
+    @pytest.mark.task(taskno=2)
+    def test_dummy(self):
+        self.assertEqual(hello('Banana'), ("Hello, World!", "Banana"))
+
+    @pytest.mark.task(taskno=2)
+    def test_hello(self):
+        self.assertEqual(hello(42), ("Hello, World!", 42))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/example-config-multiple-files-subtests-and-tasks/example_second_file_with_tasks_and_subtests_test.py
+++ b/test/example-config-multiple-files-subtests-and-tasks/example_second_file_with_tasks_and_subtests_test.py
@@ -1,0 +1,59 @@
+import unittest
+import pytest
+
+
+from example_with_config import hello
+
+
+class ExampleSecondTest(unittest.TestCase):
+
+    @pytest.mark.task(taskno=3)
+    def test_hello(self):
+        input_data = [1, 2, 5]
+        result_data = [("Hello, World!", param) for param in input_data]
+        number_of_variants = range(1, len(input_data) + 1)
+
+        for variant, param, result in zip(number_of_variants, input_data, result_data):
+            with self.subTest(f"variation #{variant}", param=param, result=result):
+                self.assertEqual(hello(param), result,
+                                 msg=f'Expected: {result} but got something else instead.')
+
+    @pytest.mark.task(taskno=3)
+    def test_abc(self):
+        input_data = ['carrot', 'cucumber', 'grass', 'tree']
+        result_data = [("Hello, World!", param) for param in input_data]
+        number_of_variants = range(1, len(input_data) + 1)
+
+        for variant, param, result in zip(number_of_variants, input_data, result_data):
+            with self.subTest(f"variation #{variant}", param=param, result=result):
+                self.assertEqual(hello(param), result,
+                                 msg=f'Expected: {result} but got something else instead.')
+
+
+class ExampleSecondOtherTest(unittest.TestCase):
+
+    @pytest.mark.task(taskno=4)
+    def test_dummy(self):
+        input_data = ['frog', 'fish', 'coconut']
+        result_data = [("Hello, World!", param) for param in input_data]
+        number_of_variants = range(1, len(input_data) + 1)
+
+        for variant, param, result in zip(number_of_variants, input_data, result_data):
+            with self.subTest(f"variation #{variant}", param=param, result=result):
+                self.assertEqual(hello(param), result,
+                                 msg=f'Expected: {result} but got something else instead.')
+
+    @pytest.mark.task(taskno=4)
+    def test_hello(self):
+        input_data = [23, 33, 39]
+        result_data = [("Hello, World!", param) for param in input_data]
+        number_of_variants = range(1, len(input_data) + 1)
+
+        for variant, param, result in zip(number_of_variants, input_data, result_data):
+            with self.subTest(f"variation #{variant}", param=param, result=result):
+                self.assertEqual(hello(param), result,
+                                 msg=f'Expected: {result} but got something else instead.')
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/example-config-multiple-files-subtests-and-tasks/example_with_config.py
+++ b/test/example-config-multiple-files-subtests-and-tasks/example_with_config.py
@@ -2,6 +2,5 @@
 
 
 def hello(param):
-    param = param
-    print("User output is captured!")
+    print("User output is captured!", param)
     return ("Hello, World!", param)

--- a/test/example-config-multiple-files-subtests-and-tasks/results.json
+++ b/test/example-config-multiple-files-subtests-and-tasks/results.json
@@ -1,0 +1,62 @@
+{
+  "version": 3,
+  "status": "pass",
+  "tests": [
+    {
+      "name": "ExampleFirstTest.test_abc",
+      "status": "pass",
+      "test_code": "self.assertEqual(hello(13), (\"Hello, World!\", 13))",
+      "task_id": 1,
+      "output": "User output is captured! 13"
+    },
+    {
+      "name": "ExampleFirstTest.test_hello",
+      "status": "pass",
+      "test_code": "self.assertEqual(hello('Hi'), (\"Hello, World!\", 'Hi'))",
+      "task_id": 1,
+      "output": "User output is captured! Hi"
+    },
+    {
+      "name": "ExampleFirstOtherTest.test_dummy",
+      "status": "pass",
+      "test_code": "self.assertEqual(hello('Banana'), (\"Hello, World!\", \"Banana\"))",
+      "task_id": 2,
+      "output": "User output is captured! Banana"
+    },
+    {
+      "name": "ExampleFirstOtherTest.test_hello",
+      "status": "pass",
+      "test_code": "self.assertEqual(hello(42), (\"Hello, World!\", 42))",
+      "task_id": 2,
+      "output": "User output is captured! 42"
+    },
+    {
+      "name": "ExampleSecondTest.test_abc",
+      "status": "pass",
+      "test_code": "input_data = ['carrot', 'cucumber', 'grass', 'tree']\nresult_data = [(\"Hello, World!\", param) for param in input_data]\nnumber_of_variants = range(1, len(input_data) + 1)\n\nfor variant, param, result in zip(number_of_variants, input_data, result_data):\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result,\n                         msg=f'Expected: {result} but got something else instead.')",
+      "task_id": 3,
+      "output": "User output is captured! carrot\nUser output is captured! cucumber\nUser output is captured! grass\nUser output is captured! tree"
+    },
+    {
+      "name": "ExampleSecondTest.test_hello",
+      "status": "pass",
+      "test_code": "input_data = [1, 2, 5]\nresult_data = [(\"Hello, World!\", param) for param in input_data]\nnumber_of_variants = range(1, len(input_data) + 1)\n\nfor variant, param, result in zip(number_of_variants, input_data, result_data):\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result,\n                         msg=f'Expected: {result} but got something else instead.')",
+      "task_id": 3,
+      "output": "User output is captured! 1\nUser output is captured! 2\nUser output is captured! 5"
+    },
+    {
+      "name": "ExampleSecondOtherTest.test_dummy",
+      "status": "pass",
+      "test_code": "input_data = ['frog', 'fish', 'coconut']\nresult_data = [(\"Hello, World!\", param) for param in input_data]\nnumber_of_variants = range(1, len(input_data) + 1)\n\nfor variant, param, result in zip(number_of_variants, input_data, result_data):\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result,\n                         msg=f'Expected: {result} but got something else instead.')",
+      "task_id": 4,
+      "output": "User output is captured! frog\nUser output is captured! fish\nUser output is captured! coconut"
+    },
+    {
+      "name": "ExampleSecondOtherTest.test_hello",
+      "status": "pass",
+      "test_code": "input_data = [23, 33, 39]\nresult_data = [(\"Hello, World!\", param) for param in input_data]\nnumber_of_variants = range(1, len(input_data) + 1)\n\nfor variant, param, result in zip(number_of_variants, input_data, result_data):\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result,\n                         msg=f'Expected: {result} but got something else instead.')",
+      "task_id": 4,
+      "output": "User output is captured! 23\nUser output is captured! 33\nUser output is captured! 39"
+    }
+  ]
+}

--- a/test/example-has-stdout-tasks-and-subtests/example_has_stdout_tasks_and_subtests.py
+++ b/test/example-has-stdout-tasks-and-subtests/example_has_stdout_tasks_and_subtests.py
@@ -1,0 +1,21 @@
+"""Example Exercism/Python solution file"""
+
+
+def hello(param):
+    print("Hello, World!", param)
+
+
+def must_truncate():
+    print(
+        """
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Vulputate ut pharetra sit amet aliquam. Amet dictum sit amet justo donec enim diam vulputate ut. Consequat nisl vel pretium lectus quam id leo. Maecenas accumsan lacus vel facilisis volutpat est velit egestas dui. Faucibus et molestie ac feugiat sed. Fringilla phasellus faucibus scelerisque eleifend donec pretium vulputate sapien. Nibh venenatis cras sed felis. Tortor at risus viverra adipiscing at. Orci dapibus ultrices in iaculis nunc. In fermentum et sollicitudin ac orci phasellus egestas tellus. Tincidunt lobortis feugiat vivamus at augue eget arcu dictum varius. Volutpat est velit egestas dui id. Non nisi est sit amet facilisis magna etiam tempor. Tincidunt id aliquet risus feugiat in ante metus dictum. Viverra aliquet eget sit amet tellus cras adipiscing. Arcu dictum varius duis at. Aliquet lectus proin nibh nisl.
+
+        Urna molestie at elementum eu. Morbi quis commodo odio aenean. Commodo elit at imperdiet dui accumsan sit amet nulla. Faucibus a pellentesque sit amet porttitor. Donec pretium vulputate sapien nec. Felis eget velit aliquet sagittis id consectetur. Nulla malesuada pellentesque elit eget gravida cum. Mauris augue neque gravida in fermentum et sollicitudin. At quis risus sed vulputate odio ut enim blandit volutpat. Enim blandit volutpat maecenas volutpat blandit. Diam in arcu cursus euismod. Congue nisi vitae suscipit tellus mauris a diam.
+
+        Adipiscing enim eu turpis egestas pretium aenean pharetra magna ac. Et odio pellentesque diam volutpat commodo sed egestas. Nulla porttitor massa id neque aliquam vestibulum morbi blandit cursus. Nisi porta lorem mollis aliquam ut porttitor. Morbi leo urna molestie at elementum eu facilisis. Vel elit scelerisque mauris pellentesque pulvinar. Fames ac turpis egestas maecenas pharetra convallis. Ornare arcu dui vivamus arcu felis bibendum ut tristique et. Blandit massa enim nec dui nunc mattis enim. Elit ullamcorper dignissim cras tincidunt lobortis feugiat vivamus at augue.
+
+        Scelerisque varius morbi enim nunc faucibus a pellentesque sit. Enim diam vulputate ut pharetra. Tempor orci eu lobortis elementum nibh tellus molestie nunc non. Cras pulvinar mattis nunc sed. Ac turpis egestas maecenas pharetra convallis posuere morbi leo. Platea dictumst quisque sagittis purus sit amet. Vitae tortor condimentum lacinia quis vel eros donec ac odio. Viverra nibh cras pulvinar mattis nunc sed blandit. Tincidunt lobortis feugiat vivamus at augue. Duis at consectetur lorem donec massa sapien faucibus. Magna ac placerat vestibulum lectus mauris ultrices. Convallis posuere morbi leo urna molestie at.
+
+        Porta non pulvinar neque laoreet suspendisse interdum consectetur libero. Id faucibus nisl tincidunt eget nullam. Ultricies lacus sed turpis tincidunt id. Hendrerit dolor magna eget est lorem ipsum. Enim ut sem viverra aliquet. Eget nulla facilisi etiam dignissim diam quis enim lobortis scelerisque. Ac tortor dignissim convallis aenean et tortor at. Non tellus orci ac auctor augue. Nec dui nunc mattis enim ut tellus. Eget nunc lobortis mattis aliquam faucibus purus in massa tempor. Elementum nibh tellus molestie nunc. Ornare lectus sit amet est placerat in. Nec feugiat in fermentum posuere urna nec tincidunt praesent. Vestibulum rhoncus est pellentesque elit. Mollis nunc sed id semper risus in. Vitae elementum curabitur vitae nunc sed velit. Duis tristique sollicitudin nibh sit amet commodo nulla facilisi."""
+    )
+    return "Goodbye!"

--- a/test/example-has-stdout-tasks-and-subtests/example_has_stdout_tasks_and_subtests_test.py
+++ b/test/example-has-stdout-tasks-and-subtests/example_has_stdout_tasks_and_subtests_test.py
@@ -1,0 +1,63 @@
+import unittest
+import pytest
+
+
+from example_has_stdout_tasks_and_subtests import hello, must_truncate
+
+
+class ExampleHasStdoutTest(unittest.TestCase):
+
+    @pytest.mark.task(taskno=1)
+    def test_hello(self):
+        input_data = [1, 2, 5, 10, 15, 23, 33, 39]
+        result_data = [("Hello, World!", param) for param in input_data]
+        number_of_variants = range(1, len(input_data) + 1)
+
+        for variant, param, result in zip(number_of_variants, input_data, result_data):
+            with self.subTest(f"variation #{variant}", param=param, result=result):
+                self.assertEqual(hello(param), result,
+                                 msg=f'Expected: {result} but got something else instead.')
+
+    @pytest.mark.task(taskno=2)
+    def test_abc(self):
+        input_data = ['frog', 'fish', 'coconut', 'pineapple', 'carrot', 'cucumber', 'grass', 'tree']
+        result_data = [("Hello, World!", param) for param in input_data]
+        number_of_variants = range(1, len(input_data) + 1)
+
+        for variant, param, result in zip(number_of_variants, input_data, result_data):
+            with self.subTest(f"variation #{variant}", param=param, result=result):
+                self.assertEqual(hello(param), result,
+                                 msg=f'Expected: {result} but got something else instead.')
+
+    @pytest.mark.task(taskno=3)
+    def test_truncation(self):
+        self.assertEqual(must_truncate(), "Hello, World!")
+
+
+class ExampleHasStdoutOtherTest(unittest.TestCase):
+
+    @pytest.mark.task(taskno=4)
+    def test_dummy(self):
+        input_data = ['frog', 'fish', 'coconut', 'pineapple', 'carrot', 'cucumber', 'grass', 'tree']
+        result_data = [("Hello, World!", param) for param in input_data]
+        number_of_variants = range(1, len(input_data) + 1)
+
+        for variant, param, result in zip(number_of_variants, input_data, result_data):
+            with self.subTest(f"variation #{variant}", param=param, result=result):
+                self.assertEqual(hello(param), result,
+                                 msg=f'Expected: {result} but got something else instead.')
+
+    @pytest.mark.task(taskno=5)
+    def test_hello(self):
+        input_data = [1, 2, 5, 10, 15, 23, 33, 39]
+        result_data = [("Hello, World!", param) for param in input_data]
+        number_of_variants = range(1, len(input_data) + 1)
+
+        for variant, param, result in zip(number_of_variants, input_data, result_data):
+            with self.subTest(f"variation #{variant}", param=param, result=result):
+                self.assertEqual(hello(param), result,
+                                 msg=f'Expected: {result} but got something else instead.')
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/example-has-stdout-tasks-and-subtests/results.json
+++ b/test/example-has-stdout-tasks-and-subtests/results.json
@@ -1,0 +1,266 @@
+{
+  "version": 3,
+  "status": "fail",
+  "tests": [
+    {
+      "name": "ExampleHasStdoutTest.test_abc",
+      "status": "fail",
+      "message": "One or more subtests for this test failed. Details can be found under each variant.",
+      "test_code": "input_data = ['frog', 'fish', 'coconut', 'pineapple', 'carrot', 'cucumber', 'grass', 'tree']\nresult_data = [(\"Hello, World!\", param) for param in input_data]\nnumber_of_variants = range(1, len(input_data) + 1)\n\nfor variant, param, result in zip(number_of_variants, input_data, result_data):\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result,\n                         msg=f'Expected: {result} but got something else instead.')",
+      "task_id": 2
+    },
+    {
+      "name": "ExampleHasStdoutTest.test_hello",
+      "status": "fail",
+      "message": "One or more subtests for this test failed. Details can be found under each variant.",
+      "test_code": "input_data = [1, 2, 5, 10, 15, 23, 33, 39]\nresult_data = [(\"Hello, World!\", param) for param in input_data]\nnumber_of_variants = range(1, len(input_data) + 1)\n\nfor variant, param, result in zip(number_of_variants, input_data, result_data):\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result,\n                         msg=f'Expected: {result} but got something else instead.')",
+      "task_id": 1
+    },
+    {
+      "name": "ExampleHasStdoutTest.test_truncation",
+      "status": "fail",
+      "message": "AssertionError: 'Goodbye!' != 'Hello, World!'\n- Goodbye!\n+ Hello, World!",
+      "test_code": "self.assertEqual(must_truncate(), \"Hello, World!\")",
+      "task_id": 3,
+      "output": "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Vulputate ut pharetra sit amet aliquam. Amet dictum sit amet justo donec enim diam vulputate ut. Consequat nisl vel pretium lectus quam id leo. Maecenas accumsan lacus vel facilisis volutpat est velit egestas dui. Faucibus et molestie ac feugiat sed. Fringilla phasellus faucibus scelerisque eleifend donec pretium vulputate s [Output was truncated. Please limit to 500 chars]"
+    },
+    {
+      "name": "ExampleHasStdoutOtherTest.test_dummy",
+      "status": "fail",
+      "message": "One or more subtests for this test failed. Details can be found under each variant.",
+      "test_code": "input_data = ['frog', 'fish', 'coconut', 'pineapple', 'carrot', 'cucumber', 'grass', 'tree']\nresult_data = [(\"Hello, World!\", param) for param in input_data]\nnumber_of_variants = range(1, len(input_data) + 1)\n\nfor variant, param, result in zip(number_of_variants, input_data, result_data):\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result,\n                         msg=f'Expected: {result} but got something else instead.')",
+      "task_id": 4
+    },
+    {
+      "name": "ExampleHasStdoutOtherTest.test_hello",
+      "status": "fail",
+      "message": "One or more subtests for this test failed. Details can be found under each variant.",
+      "test_code": "input_data = [1, 2, 5, 10, 15, 23, 33, 39]\nresult_data = [(\"Hello, World!\", param) for param in input_data]\nnumber_of_variants = range(1, len(input_data) + 1)\n\nfor variant, param, result in zip(number_of_variants, input_data, result_data):\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result,\n                         msg=f'Expected: {result} but got something else instead.')",
+      "task_id": 5
+    },
+    {
+      "name": "ExampleHasStdoutTest.test_hello [variation #1] (param=1, result=('Hello, World!', 1))",
+      "status": "fail",
+      "message": "AssertionError: None != ('Hello, World!', 1) : Expected: ('Hello, World!', 1) but got something else instead.",
+      "test_code": "input_data = [1, 2, 5, 10, 15, 23, 33, 39]\nresult_data = [(\"Hello, World!\", param) for param in input_data]\nnumber_of_variants = range(1, len(input_data) + 1)\n\nfor variant, param, result in zip(number_of_variants, input_data, result_data):\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result,\n                         msg=f'Expected: {result} but got something else instead.')",
+      "task_id": 1
+    },
+    {
+      "name": "ExampleHasStdoutTest.test_hello [variation #2] (param=2, result=('Hello, World!', 2))",
+      "status": "fail",
+      "message": "AssertionError: None != ('Hello, World!', 2) : Expected: ('Hello, World!', 2) but got something else instead.",
+      "test_code": "input_data = [1, 2, 5, 10, 15, 23, 33, 39]\nresult_data = [(\"Hello, World!\", param) for param in input_data]\nnumber_of_variants = range(1, len(input_data) + 1)\n\nfor variant, param, result in zip(number_of_variants, input_data, result_data):\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result,\n                         msg=f'Expected: {result} but got something else instead.')",
+      "task_id": 1
+    },
+    {
+      "name": "ExampleHasStdoutTest.test_hello [variation #3] (param=5, result=('Hello, World!', 5))",
+      "status": "fail",
+      "message": "AssertionError: None != ('Hello, World!', 5) : Expected: ('Hello, World!', 5) but got something else instead.",
+      "test_code": "input_data = [1, 2, 5, 10, 15, 23, 33, 39]\nresult_data = [(\"Hello, World!\", param) for param in input_data]\nnumber_of_variants = range(1, len(input_data) + 1)\n\nfor variant, param, result in zip(number_of_variants, input_data, result_data):\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result,\n                         msg=f'Expected: {result} but got something else instead.')",
+      "task_id": 1
+    },
+    {
+      "name": "ExampleHasStdoutTest.test_hello [variation #4] (param=10, result=('Hello, World!', 10))",
+      "status": "fail",
+      "message": "AssertionError: None != ('Hello, World!', 10) : Expected: ('Hello, World!', 10) but got something else instead.",
+      "test_code": "input_data = [1, 2, 5, 10, 15, 23, 33, 39]\nresult_data = [(\"Hello, World!\", param) for param in input_data]\nnumber_of_variants = range(1, len(input_data) + 1)\n\nfor variant, param, result in zip(number_of_variants, input_data, result_data):\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result,\n                         msg=f'Expected: {result} but got something else instead.')",
+      "task_id": 1
+    },
+    {
+      "name": "ExampleHasStdoutTest.test_hello [variation #5] (param=15, result=('Hello, World!', 15))",
+      "status": "fail",
+      "message": "AssertionError: None != ('Hello, World!', 15) : Expected: ('Hello, World!', 15) but got something else instead.",
+      "test_code": "input_data = [1, 2, 5, 10, 15, 23, 33, 39]\nresult_data = [(\"Hello, World!\", param) for param in input_data]\nnumber_of_variants = range(1, len(input_data) + 1)\n\nfor variant, param, result in zip(number_of_variants, input_data, result_data):\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result,\n                         msg=f'Expected: {result} but got something else instead.')",
+      "task_id": 1
+    },
+    {
+      "name": "ExampleHasStdoutTest.test_hello [variation #6] (param=23, result=('Hello, World!', 23))",
+      "status": "fail",
+      "message": "AssertionError: None != ('Hello, World!', 23) : Expected: ('Hello, World!', 23) but got something else instead.",
+      "test_code": "input_data = [1, 2, 5, 10, 15, 23, 33, 39]\nresult_data = [(\"Hello, World!\", param) for param in input_data]\nnumber_of_variants = range(1, len(input_data) + 1)\n\nfor variant, param, result in zip(number_of_variants, input_data, result_data):\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result,\n                         msg=f'Expected: {result} but got something else instead.')",
+      "task_id": 1
+    },
+    {
+      "name": "ExampleHasStdoutTest.test_hello [variation #7] (param=33, result=('Hello, World!', 33))",
+      "status": "fail",
+      "message": "AssertionError: None != ('Hello, World!', 33) : Expected: ('Hello, World!', 33) but got something else instead.",
+      "test_code": "input_data = [1, 2, 5, 10, 15, 23, 33, 39]\nresult_data = [(\"Hello, World!\", param) for param in input_data]\nnumber_of_variants = range(1, len(input_data) + 1)\n\nfor variant, param, result in zip(number_of_variants, input_data, result_data):\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result,\n                         msg=f'Expected: {result} but got something else instead.')",
+      "task_id": 1
+    },
+    {
+      "name": "ExampleHasStdoutTest.test_hello [variation #8] (param=39, result=('Hello, World!', 39))",
+      "status": "fail",
+      "message": "AssertionError: None != ('Hello, World!', 39) : Expected: ('Hello, World!', 39) but got something else instead.",
+      "test_code": "input_data = [1, 2, 5, 10, 15, 23, 33, 39]\nresult_data = [(\"Hello, World!\", param) for param in input_data]\nnumber_of_variants = range(1, len(input_data) + 1)\n\nfor variant, param, result in zip(number_of_variants, input_data, result_data):\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result,\n                         msg=f'Expected: {result} but got something else instead.')",
+      "task_id": 1
+    },
+    {
+      "name": "ExampleHasStdoutTest.test_abc [variation #1] (param='frog', result=('Hello, World!', 'frog'))",
+      "status": "fail",
+      "message": "AssertionError: None != ('Hello, World!', 'frog') : Expected: ('Hello, World!', 'frog') but got something else instead.",
+      "test_code": "input_data = ['frog', 'fish', 'coconut', 'pineapple', 'carrot', 'cucumber', 'grass', 'tree']\nresult_data = [(\"Hello, World!\", param) for param in input_data]\nnumber_of_variants = range(1, len(input_data) + 1)\n\nfor variant, param, result in zip(number_of_variants, input_data, result_data):\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result,\n                         msg=f'Expected: {result} but got something else instead.')",
+      "task_id": 2
+    },
+    {
+      "name": "ExampleHasStdoutTest.test_abc [variation #2] (param='fish', result=('Hello, World!', 'fish'))",
+      "status": "fail",
+      "message": "AssertionError: None != ('Hello, World!', 'fish') : Expected: ('Hello, World!', 'fish') but got something else instead.",
+      "test_code": "input_data = ['frog', 'fish', 'coconut', 'pineapple', 'carrot', 'cucumber', 'grass', 'tree']\nresult_data = [(\"Hello, World!\", param) for param in input_data]\nnumber_of_variants = range(1, len(input_data) + 1)\n\nfor variant, param, result in zip(number_of_variants, input_data, result_data):\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result,\n                         msg=f'Expected: {result} but got something else instead.')",
+      "task_id": 2
+    },
+    {
+      "name": "ExampleHasStdoutTest.test_abc [variation #3] (param='coconut', result=('Hello, World!', 'coconut'))",
+      "status": "fail",
+      "message": "AssertionError: None != ('Hello, World!', 'coconut') : Expected: ('Hello, World!', 'coconut') but got something else instead.",
+      "test_code": "input_data = ['frog', 'fish', 'coconut', 'pineapple', 'carrot', 'cucumber', 'grass', 'tree']\nresult_data = [(\"Hello, World!\", param) for param in input_data]\nnumber_of_variants = range(1, len(input_data) + 1)\n\nfor variant, param, result in zip(number_of_variants, input_data, result_data):\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result,\n                         msg=f'Expected: {result} but got something else instead.')",
+      "task_id": 2
+    },
+    {
+      "name": "ExampleHasStdoutTest.test_abc [variation #4] (param='pineapple', result=('Hello, World!', 'pineapple'))",
+      "status": "fail",
+      "message": "AssertionError: None != ('Hello, World!', 'pineapple') : Expected: ('Hello, World!', 'pineapple') but got something else instead.",
+      "test_code": "input_data = ['frog', 'fish', 'coconut', 'pineapple', 'carrot', 'cucumber', 'grass', 'tree']\nresult_data = [(\"Hello, World!\", param) for param in input_data]\nnumber_of_variants = range(1, len(input_data) + 1)\n\nfor variant, param, result in zip(number_of_variants, input_data, result_data):\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result,\n                         msg=f'Expected: {result} but got something else instead.')",
+      "task_id": 2
+    },
+    {
+      "name": "ExampleHasStdoutTest.test_abc [variation #5] (param='carrot', result=('Hello, World!', 'carrot'))",
+      "status": "fail",
+      "message": "AssertionError: None != ('Hello, World!', 'carrot') : Expected: ('Hello, World!', 'carrot') but got something else instead.",
+      "test_code": "input_data = ['frog', 'fish', 'coconut', 'pineapple', 'carrot', 'cucumber', 'grass', 'tree']\nresult_data = [(\"Hello, World!\", param) for param in input_data]\nnumber_of_variants = range(1, len(input_data) + 1)\n\nfor variant, param, result in zip(number_of_variants, input_data, result_data):\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result,\n                         msg=f'Expected: {result} but got something else instead.')",
+      "task_id": 2
+    },
+    {
+      "name": "ExampleHasStdoutTest.test_abc [variation #6] (param='cucumber', result=('Hello, World!', 'cucumber'))",
+      "status": "fail",
+      "message": "AssertionError: None != ('Hello, World!', 'cucumber') : Expected: ('Hello, World!', 'cucumber') but got something else instead.",
+      "test_code": "input_data = ['frog', 'fish', 'coconut', 'pineapple', 'carrot', 'cucumber', 'grass', 'tree']\nresult_data = [(\"Hello, World!\", param) for param in input_data]\nnumber_of_variants = range(1, len(input_data) + 1)\n\nfor variant, param, result in zip(number_of_variants, input_data, result_data):\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result,\n                         msg=f'Expected: {result} but got something else instead.')",
+      "task_id": 2
+    },
+    {
+      "name": "ExampleHasStdoutTest.test_abc [variation #7] (param='grass', result=('Hello, World!', 'grass'))",
+      "status": "fail",
+      "message": "AssertionError: None != ('Hello, World!', 'grass') : Expected: ('Hello, World!', 'grass') but got something else instead.",
+      "test_code": "input_data = ['frog', 'fish', 'coconut', 'pineapple', 'carrot', 'cucumber', 'grass', 'tree']\nresult_data = [(\"Hello, World!\", param) for param in input_data]\nnumber_of_variants = range(1, len(input_data) + 1)\n\nfor variant, param, result in zip(number_of_variants, input_data, result_data):\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result,\n                         msg=f'Expected: {result} but got something else instead.')",
+      "task_id": 2
+    },
+    {
+      "name": "ExampleHasStdoutTest.test_abc [variation #8] (param='tree', result=('Hello, World!', 'tree'))",
+      "status": "fail",
+      "message": "AssertionError: None != ('Hello, World!', 'tree') : Expected: ('Hello, World!', 'tree') but got something else instead.",
+      "test_code": "input_data = ['frog', 'fish', 'coconut', 'pineapple', 'carrot', 'cucumber', 'grass', 'tree']\nresult_data = [(\"Hello, World!\", param) for param in input_data]\nnumber_of_variants = range(1, len(input_data) + 1)\n\nfor variant, param, result in zip(number_of_variants, input_data, result_data):\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result,\n                         msg=f'Expected: {result} but got something else instead.')",
+      "task_id": 2
+    },
+    {
+      "name": "ExampleHasStdoutOtherTest.test_dummy [variation #1] (param='frog', result=('Hello, World!', 'frog'))",
+      "status": "fail",
+      "message": "AssertionError: None != ('Hello, World!', 'frog') : Expected: ('Hello, World!', 'frog') but got something else instead.",
+      "test_code": "input_data = ['frog', 'fish', 'coconut', 'pineapple', 'carrot', 'cucumber', 'grass', 'tree']\nresult_data = [(\"Hello, World!\", param) for param in input_data]\nnumber_of_variants = range(1, len(input_data) + 1)\n\nfor variant, param, result in zip(number_of_variants, input_data, result_data):\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result,\n                         msg=f'Expected: {result} but got something else instead.')",
+      "task_id": 4
+    },
+    {
+      "name": "ExampleHasStdoutOtherTest.test_dummy [variation #2] (param='fish', result=('Hello, World!', 'fish'))",
+      "status": "fail",
+      "message": "AssertionError: None != ('Hello, World!', 'fish') : Expected: ('Hello, World!', 'fish') but got something else instead.",
+      "test_code": "input_data = ['frog', 'fish', 'coconut', 'pineapple', 'carrot', 'cucumber', 'grass', 'tree']\nresult_data = [(\"Hello, World!\", param) for param in input_data]\nnumber_of_variants = range(1, len(input_data) + 1)\n\nfor variant, param, result in zip(number_of_variants, input_data, result_data):\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result,\n                         msg=f'Expected: {result} but got something else instead.')",
+      "task_id": 4
+    },
+    {
+      "name": "ExampleHasStdoutOtherTest.test_dummy [variation #3] (param='coconut', result=('Hello, World!', 'coconut'))",
+      "status": "fail",
+      "message": "AssertionError: None != ('Hello, World!', 'coconut') : Expected: ('Hello, World!', 'coconut') but got something else instead.",
+      "test_code": "input_data = ['frog', 'fish', 'coconut', 'pineapple', 'carrot', 'cucumber', 'grass', 'tree']\nresult_data = [(\"Hello, World!\", param) for param in input_data]\nnumber_of_variants = range(1, len(input_data) + 1)\n\nfor variant, param, result in zip(number_of_variants, input_data, result_data):\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result,\n                         msg=f'Expected: {result} but got something else instead.')",
+      "task_id": 4
+    },
+    {
+      "name": "ExampleHasStdoutOtherTest.test_dummy [variation #4] (param='pineapple', result=('Hello, World!', 'pineapple'))",
+      "status": "fail",
+      "message": "AssertionError: None != ('Hello, World!', 'pineapple') : Expected: ('Hello, World!', 'pineapple') but got something else instead.",
+      "test_code": "input_data = ['frog', 'fish', 'coconut', 'pineapple', 'carrot', 'cucumber', 'grass', 'tree']\nresult_data = [(\"Hello, World!\", param) for param in input_data]\nnumber_of_variants = range(1, len(input_data) + 1)\n\nfor variant, param, result in zip(number_of_variants, input_data, result_data):\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result,\n                         msg=f'Expected: {result} but got something else instead.')",
+      "task_id": 4
+    },
+    {
+      "name": "ExampleHasStdoutOtherTest.test_dummy [variation #5] (param='carrot', result=('Hello, World!', 'carrot'))",
+      "status": "fail",
+      "message": "AssertionError: None != ('Hello, World!', 'carrot') : Expected: ('Hello, World!', 'carrot') but got something else instead.",
+      "test_code": "input_data = ['frog', 'fish', 'coconut', 'pineapple', 'carrot', 'cucumber', 'grass', 'tree']\nresult_data = [(\"Hello, World!\", param) for param in input_data]\nnumber_of_variants = range(1, len(input_data) + 1)\n\nfor variant, param, result in zip(number_of_variants, input_data, result_data):\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result,\n                         msg=f'Expected: {result} but got something else instead.')",
+      "task_id": 4
+    },
+    {
+      "name": "ExampleHasStdoutOtherTest.test_dummy [variation #6] (param='cucumber', result=('Hello, World!', 'cucumber'))",
+      "status": "fail",
+      "message": "AssertionError: None != ('Hello, World!', 'cucumber') : Expected: ('Hello, World!', 'cucumber') but got something else instead.",
+      "test_code": "input_data = ['frog', 'fish', 'coconut', 'pineapple', 'carrot', 'cucumber', 'grass', 'tree']\nresult_data = [(\"Hello, World!\", param) for param in input_data]\nnumber_of_variants = range(1, len(input_data) + 1)\n\nfor variant, param, result in zip(number_of_variants, input_data, result_data):\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result,\n                         msg=f'Expected: {result} but got something else instead.')",
+      "task_id": 4
+    },
+    {
+      "name": "ExampleHasStdoutOtherTest.test_dummy [variation #7] (param='grass', result=('Hello, World!', 'grass'))",
+      "status": "fail",
+      "message": "AssertionError: None != ('Hello, World!', 'grass') : Expected: ('Hello, World!', 'grass') but got something else instead.",
+      "test_code": "input_data = ['frog', 'fish', 'coconut', 'pineapple', 'carrot', 'cucumber', 'grass', 'tree']\nresult_data = [(\"Hello, World!\", param) for param in input_data]\nnumber_of_variants = range(1, len(input_data) + 1)\n\nfor variant, param, result in zip(number_of_variants, input_data, result_data):\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result,\n                         msg=f'Expected: {result} but got something else instead.')",
+      "task_id": 4
+    },
+    {
+      "name": "ExampleHasStdoutOtherTest.test_dummy [variation #8] (param='tree', result=('Hello, World!', 'tree'))",
+      "status": "fail",
+      "message": "AssertionError: None != ('Hello, World!', 'tree') : Expected: ('Hello, World!', 'tree') but got something else instead.",
+      "test_code": "input_data = ['frog', 'fish', 'coconut', 'pineapple', 'carrot', 'cucumber', 'grass', 'tree']\nresult_data = [(\"Hello, World!\", param) for param in input_data]\nnumber_of_variants = range(1, len(input_data) + 1)\n\nfor variant, param, result in zip(number_of_variants, input_data, result_data):\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result,\n                         msg=f'Expected: {result} but got something else instead.')",
+      "task_id": 4
+    },
+    {
+      "name": "ExampleHasStdoutOtherTest.test_hello [variation #1] (param=1, result=('Hello, World!', 1))",
+      "status": "fail",
+      "message": "AssertionError: None != ('Hello, World!', 1) : Expected: ('Hello, World!', 1) but got something else instead.",
+      "test_code": "input_data = [1, 2, 5, 10, 15, 23, 33, 39]\nresult_data = [(\"Hello, World!\", param) for param in input_data]\nnumber_of_variants = range(1, len(input_data) + 1)\n\nfor variant, param, result in zip(number_of_variants, input_data, result_data):\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result,\n                         msg=f'Expected: {result} but got something else instead.')",
+      "task_id": 5
+    },
+    {
+      "name": "ExampleHasStdoutOtherTest.test_hello [variation #2] (param=2, result=('Hello, World!', 2))",
+      "status": "fail",
+      "message": "AssertionError: None != ('Hello, World!', 2) : Expected: ('Hello, World!', 2) but got something else instead.",
+      "test_code": "input_data = [1, 2, 5, 10, 15, 23, 33, 39]\nresult_data = [(\"Hello, World!\", param) for param in input_data]\nnumber_of_variants = range(1, len(input_data) + 1)\n\nfor variant, param, result in zip(number_of_variants, input_data, result_data):\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result,\n                         msg=f'Expected: {result} but got something else instead.')",
+      "task_id": 5
+    },
+    {
+      "name": "ExampleHasStdoutOtherTest.test_hello [variation #3] (param=5, result=('Hello, World!', 5))",
+      "status": "fail",
+      "message": "AssertionError: None != ('Hello, World!', 5) : Expected: ('Hello, World!', 5) but got something else instead.",
+      "test_code": "input_data = [1, 2, 5, 10, 15, 23, 33, 39]\nresult_data = [(\"Hello, World!\", param) for param in input_data]\nnumber_of_variants = range(1, len(input_data) + 1)\n\nfor variant, param, result in zip(number_of_variants, input_data, result_data):\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result,\n                         msg=f'Expected: {result} but got something else instead.')",
+      "task_id": 5
+    },
+    {
+      "name": "ExampleHasStdoutOtherTest.test_hello [variation #4] (param=10, result=('Hello, World!', 10))",
+      "status": "fail",
+      "message": "AssertionError: None != ('Hello, World!', 10) : Expected: ('Hello, World!', 10) but got something else instead.",
+      "test_code": "input_data = [1, 2, 5, 10, 15, 23, 33, 39]\nresult_data = [(\"Hello, World!\", param) for param in input_data]\nnumber_of_variants = range(1, len(input_data) + 1)\n\nfor variant, param, result in zip(number_of_variants, input_data, result_data):\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result,\n                         msg=f'Expected: {result} but got something else instead.')",
+      "task_id": 5
+    },
+    {
+      "name": "ExampleHasStdoutOtherTest.test_hello [variation #5] (param=15, result=('Hello, World!', 15))",
+      "status": "fail",
+      "message": "AssertionError: None != ('Hello, World!', 15) : Expected: ('Hello, World!', 15) but got something else instead.",
+      "test_code": "input_data = [1, 2, 5, 10, 15, 23, 33, 39]\nresult_data = [(\"Hello, World!\", param) for param in input_data]\nnumber_of_variants = range(1, len(input_data) + 1)\n\nfor variant, param, result in zip(number_of_variants, input_data, result_data):\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result,\n                         msg=f'Expected: {result} but got something else instead.')",
+      "task_id": 5
+    },
+    {
+      "name": "ExampleHasStdoutOtherTest.test_hello [variation #6] (param=23, result=('Hello, World!', 23))",
+      "status": "fail",
+      "message": "AssertionError: None != ('Hello, World!', 23) : Expected: ('Hello, World!', 23) but got something else instead.",
+      "test_code": "input_data = [1, 2, 5, 10, 15, 23, 33, 39]\nresult_data = [(\"Hello, World!\", param) for param in input_data]\nnumber_of_variants = range(1, len(input_data) + 1)\n\nfor variant, param, result in zip(number_of_variants, input_data, result_data):\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result,\n                         msg=f'Expected: {result} but got something else instead.')",
+      "task_id": 5
+    },
+    {
+      "name": "ExampleHasStdoutOtherTest.test_hello [variation #7] (param=33, result=('Hello, World!', 33))",
+      "status": "fail",
+      "message": "AssertionError: None != ('Hello, World!', 33) : Expected: ('Hello, World!', 33) but got something else instead.",
+      "test_code": "input_data = [1, 2, 5, 10, 15, 23, 33, 39]\nresult_data = [(\"Hello, World!\", param) for param in input_data]\nnumber_of_variants = range(1, len(input_data) + 1)\n\nfor variant, param, result in zip(number_of_variants, input_data, result_data):\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result,\n                         msg=f'Expected: {result} but got something else instead.')",
+      "task_id": 5
+    },
+    {
+      "name": "ExampleHasStdoutOtherTest.test_hello [variation #8] (param=39, result=('Hello, World!', 39))",
+      "status": "fail",
+      "message": "AssertionError: None != ('Hello, World!', 39) : Expected: ('Hello, World!', 39) but got something else instead.",
+      "test_code": "input_data = [1, 2, 5, 10, 15, 23, 33, 39]\nresult_data = [(\"Hello, World!\", param) for param in input_data]\nnumber_of_variants = range(1, len(input_data) + 1)\n\nfor variant, param, result in zip(number_of_variants, input_data, result_data):\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result,\n                         msg=f'Expected: {result} but got something else instead.')",
+      "task_id": 5
+    }
+  ]
+}

--- a/test/example-partial-failure-with-subtests/results.json
+++ b/test/example-partial-failure-with-subtests/results.json
@@ -5,83 +5,83 @@
     {
       "name": "ExamplePartialFailureWithSubtestsTest.test_abc",
       "status": "pass",
-      "test_code": "input_data = ['frog', 'fish', 'coconut', 'pineapple', 'carrot', 'cucumber', 'grass', 'tree']\nresult_data = [(\"Hello, World!\", param) for param in input_data]\nnumber_of_variants = range(1, len(input_data) + 1)\n\nfor variant, param, result in zip(number_of_variants, input_data, result_data):\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result,",
+      "test_code": "input_data = ['frog', 'fish', 'coconut', 'pineapple', 'carrot', 'cucumber', 'grass', 'tree']\nresult_data = [(\"Hello, World!\", param) for param in input_data]\nnumber_of_variants = range(1, len(input_data) + 1)\n\nfor variant, param, result in zip(number_of_variants, input_data, result_data):\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result,\n                         msg=f'Expected: {result} but got something else instead.')",
       "task_id": 1
     },
     {
       "name": "ExamplePartialFailureWithSubtestsTest.test_hello",
       "status": "fail",
       "message": "One or more subtests for this test failed. Details can be found under each variant.",
-      "test_code": "input_data = [1, 2, 5, 10]\nresult_data = [(\"Hello, World!\", param) for param in input_data]\nnumber_of_variants = range(1, len(input_data) + 1)\n\nfor variant, param, result in zip(number_of_variants, input_data, result_data):\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result,",
+      "test_code": "input_data = [1, 2, 5, 10]\nresult_data = [(\"Hello, World!\", param) for param in input_data]\nnumber_of_variants = range(1, len(input_data) + 1)\n\nfor variant, param, result in zip(number_of_variants, input_data, result_data):\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result,\n                         msg=f'Expected: {result} but got something else instead.')",
       "task_id": 1
     },
     {
       "name": "ExamplePartialFailureWithSubtestsOtherTest.test_dummy",
       "status": "pass",
-      "test_code": "input_data = ['frog', 'fish', 'coconut', 'pineapple', 'carrot', 'cucumber', 'grass', 'tree']\nresult_data = [(\"Hello, World!\", param) for param in input_data]\nnumber_of_variants = range(1, len(input_data) + 1)\n\nfor variant, param, result in zip(number_of_variants, input_data, result_data):\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result,",
+      "test_code": "input_data = ['frog', 'fish', 'coconut', 'pineapple', 'carrot', 'cucumber', 'grass', 'tree']\nresult_data = [(\"Hello, World!\", param) for param in input_data]\nnumber_of_variants = range(1, len(input_data) + 1)\n\nfor variant, param, result in zip(number_of_variants, input_data, result_data):\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result,\n                         msg=f'Expected: {result} but got something else instead.')",
       "task_id": 2
     },
     {
       "name": "ExamplePartialFailureWithSubtestsOtherTest.test_hello",
       "status": "fail",
       "message": "One or more subtests for this test failed. Details can be found under each variant.",
-      "test_code": "input_data = [15, 23, 33, 39]\nresult_data = [(\"Hello, World!\", param) for param in input_data]\nnumber_of_variants = range(1, len(input_data) + 1)\n\nfor variant, param, result in zip(number_of_variants, input_data, result_data):\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result,",
+      "test_code": "input_data = [15, 23, 33, 39]\nresult_data = [(\"Hello, World!\", param) for param in input_data]\nnumber_of_variants = range(1, len(input_data) + 1)\n\nfor variant, param, result in zip(number_of_variants, input_data, result_data):\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result,\n                         msg=f'Expected: {result} but got something else instead.')",
       "task_id": 2
     },
     {
       "name": "ExamplePartialFailureWithSubtestsTest.test_hello [variation #1] (param=1, result=('Hello, World!', 1))",
       "status": "fail",
       "message": "AssertionError: 'Hello, World!' != ('Hello, World!', 1) : Expected: ('Hello, World!', 1) but got something else instead.",
-      "test_code": "input_data = [1, 2, 5, 10]\nresult_data = [(\"Hello, World!\", param) for param in input_data]\nnumber_of_variants = range(1, len(input_data) + 1)\n\nfor variant, param, result in zip(number_of_variants, input_data, result_data):\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result,",
+      "test_code": "input_data = [1, 2, 5, 10]\nresult_data = [(\"Hello, World!\", param) for param in input_data]\nnumber_of_variants = range(1, len(input_data) + 1)\n\nfor variant, param, result in zip(number_of_variants, input_data, result_data):\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result,\n                         msg=f'Expected: {result} but got something else instead.')",
       "task_id": 1
     },
     {
       "name": "ExamplePartialFailureWithSubtestsTest.test_hello [variation #2] (param=2, result=('Hello, World!', 2))",
       "status": "fail",
       "message": "AssertionError: 'Hello, World!' != ('Hello, World!', 2) : Expected: ('Hello, World!', 2) but got something else instead.",
-      "test_code": "input_data = [1, 2, 5, 10]\nresult_data = [(\"Hello, World!\", param) for param in input_data]\nnumber_of_variants = range(1, len(input_data) + 1)\n\nfor variant, param, result in zip(number_of_variants, input_data, result_data):\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result,",
+      "test_code": "input_data = [1, 2, 5, 10]\nresult_data = [(\"Hello, World!\", param) for param in input_data]\nnumber_of_variants = range(1, len(input_data) + 1)\n\nfor variant, param, result in zip(number_of_variants, input_data, result_data):\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result,\n                         msg=f'Expected: {result} but got something else instead.')",
       "task_id": 1
     },
     {
       "name": "ExamplePartialFailureWithSubtestsTest.test_hello [variation #3] (param=5, result=('Hello, World!', 5))",
       "status": "fail",
       "message": "AssertionError: 'Hello, World!' != ('Hello, World!', 5) : Expected: ('Hello, World!', 5) but got something else instead.",
-      "test_code": "input_data = [1, 2, 5, 10]\nresult_data = [(\"Hello, World!\", param) for param in input_data]\nnumber_of_variants = range(1, len(input_data) + 1)\n\nfor variant, param, result in zip(number_of_variants, input_data, result_data):\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result,",
+      "test_code": "input_data = [1, 2, 5, 10]\nresult_data = [(\"Hello, World!\", param) for param in input_data]\nnumber_of_variants = range(1, len(input_data) + 1)\n\nfor variant, param, result in zip(number_of_variants, input_data, result_data):\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result,\n                         msg=f'Expected: {result} but got something else instead.')",
       "task_id": 1
     },
     {
       "name": "ExamplePartialFailureWithSubtestsTest.test_hello [variation #4] (param=10, result=('Hello, World!', 10))",
       "status": "fail",
       "message": "AssertionError: 'Hello, World!' != ('Hello, World!', 10) : Expected: ('Hello, World!', 10) but got something else instead.",
-      "test_code": "input_data = [1, 2, 5, 10]\nresult_data = [(\"Hello, World!\", param) for param in input_data]\nnumber_of_variants = range(1, len(input_data) + 1)\n\nfor variant, param, result in zip(number_of_variants, input_data, result_data):\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result,",
+      "test_code": "input_data = [1, 2, 5, 10]\nresult_data = [(\"Hello, World!\", param) for param in input_data]\nnumber_of_variants = range(1, len(input_data) + 1)\n\nfor variant, param, result in zip(number_of_variants, input_data, result_data):\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result,\n                         msg=f'Expected: {result} but got something else instead.')",
       "task_id": 1
     },
     {
       "name": "ExamplePartialFailureWithSubtestsOtherTest.test_hello [variation #1] (param=15, result=('Hello, World!', 15))",
       "status": "fail",
       "message": "AssertionError: 'Hello, World!' != ('Hello, World!', 15) : Expected: ('Hello, World!', 15) but got something else instead.",
-      "test_code": "input_data = [15, 23, 33, 39]\nresult_data = [(\"Hello, World!\", param) for param in input_data]\nnumber_of_variants = range(1, len(input_data) + 1)\n\nfor variant, param, result in zip(number_of_variants, input_data, result_data):\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result,",
+      "test_code": "input_data = [15, 23, 33, 39]\nresult_data = [(\"Hello, World!\", param) for param in input_data]\nnumber_of_variants = range(1, len(input_data) + 1)\n\nfor variant, param, result in zip(number_of_variants, input_data, result_data):\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result,\n                         msg=f'Expected: {result} but got something else instead.')",
       "task_id": 2
     },
     {
       "name": "ExamplePartialFailureWithSubtestsOtherTest.test_hello [variation #2] (param=23, result=('Hello, World!', 23))",
       "status": "fail",
       "message": "AssertionError: 'Hello, World!' != ('Hello, World!', 23) : Expected: ('Hello, World!', 23) but got something else instead.",
-      "test_code": "input_data = [15, 23, 33, 39]\nresult_data = [(\"Hello, World!\", param) for param in input_data]\nnumber_of_variants = range(1, len(input_data) + 1)\n\nfor variant, param, result in zip(number_of_variants, input_data, result_data):\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result,",
+      "test_code": "input_data = [15, 23, 33, 39]\nresult_data = [(\"Hello, World!\", param) for param in input_data]\nnumber_of_variants = range(1, len(input_data) + 1)\n\nfor variant, param, result in zip(number_of_variants, input_data, result_data):\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result,\n                         msg=f'Expected: {result} but got something else instead.')",
       "task_id": 2
     },
     {
       "name": "ExamplePartialFailureWithSubtestsOtherTest.test_hello [variation #3] (param=33, result=('Hello, World!', 33))",
       "status": "fail",
       "message": "AssertionError: 'Hello, World!' != ('Hello, World!', 33) : Expected: ('Hello, World!', 33) but got something else instead.",
-      "test_code": "input_data = [15, 23, 33, 39]\nresult_data = [(\"Hello, World!\", param) for param in input_data]\nnumber_of_variants = range(1, len(input_data) + 1)\n\nfor variant, param, result in zip(number_of_variants, input_data, result_data):\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result,",
+      "test_code": "input_data = [15, 23, 33, 39]\nresult_data = [(\"Hello, World!\", param) for param in input_data]\nnumber_of_variants = range(1, len(input_data) + 1)\n\nfor variant, param, result in zip(number_of_variants, input_data, result_data):\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result,\n                         msg=f'Expected: {result} but got something else instead.')",
       "task_id": 2
     },
     {
       "name": "ExamplePartialFailureWithSubtestsOtherTest.test_hello [variation #4] (param=39, result=('Hello, World!', 39))",
       "status": "fail",
       "message": "AssertionError: 'Hello, World!' != ('Hello, World!', 39) : Expected: ('Hello, World!', 39) but got something else instead.",
-      "test_code": "input_data = [15, 23, 33, 39]\nresult_data = [(\"Hello, World!\", param) for param in input_data]\nnumber_of_variants = range(1, len(input_data) + 1)\n\nfor variant, param, result in zip(number_of_variants, input_data, result_data):\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result,",
+      "test_code": "input_data = [15, 23, 33, 39]\nresult_data = [(\"Hello, World!\", param) for param in input_data]\nnumber_of_variants = range(1, len(input_data) + 1)\n\nfor variant, param, result in zip(number_of_variants, input_data, result_data):\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result,\n                         msg=f'Expected: {result} but got something else instead.')",
       "task_id": 2
     }
   ]

--- a/test/example-success-with-subtests/results.json
+++ b/test/example-success-with-subtests/results.json
@@ -5,26 +5,30 @@
     {
       "name": "ExampleSuccessWithSubtestsTest.test_abc",
       "status": "pass",
-      "test_code": "input_data = ['frog', 'fish', 'coconut', 'pineapple', 'carrot', 'cucumber', 'grass', 'tree']\nresult_data = [(\"Hello, World!\", param) for param in input_data]\nnumber_of_variants = range(1, len(input_data) + 1)\n\nfor variant, param, result in zip(number_of_variants, input_data, result_data):\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result,",
-      "task_id": 1
+      "test_code": "input_data = ['frog', 'fish', 'coconut', 'pineapple', 'carrot', 'cucumber', 'grass', 'tree']\nresult_data = [(\"Hello, World!\", param) for param in input_data]\nnumber_of_variants = range(1, len(input_data) + 1)\n\nfor variant, param, result in zip(number_of_variants, input_data, result_data):\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result,\n                         msg=f'Expected: {result} but got something else instead.')",
+      "task_id": 1,
+      "output": "User output is captured!\nUser output is captured!\nUser output is captured!\nUser output is captured!\nUser output is captured!\nUser output is captured!\nUser output is captured!\nUser output is captured!"
     },
     {
       "name": "ExampleSuccessWithSubtestsTest.test_hello",
       "status": "pass",
-      "test_code": "input_data = [1, 2, 5, 10, 15, 23, 33, 39]\nresult_data = [(\"Hello, World!\", param) for param in input_data]\nnumber_of_variants = range(1, len(input_data) + 1)\n\nfor variant, param, result in zip(number_of_variants, input_data, result_data):\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result,",
-      "task_id": 1
+      "test_code": "input_data = [1, 2, 5, 10, 15, 23, 33, 39]\nresult_data = [(\"Hello, World!\", param) for param in input_data]\nnumber_of_variants = range(1, len(input_data) + 1)\n\nfor variant, param, result in zip(number_of_variants, input_data, result_data):\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result,\n                         msg=f'Expected: {result} but got something else instead.')",
+      "task_id": 1,
+      "output": "User output is captured!\nUser output is captured!\nUser output is captured!\nUser output is captured!\nUser output is captured!\nUser output is captured!\nUser output is captured!\nUser output is captured!"
     },
     {
       "name": "ExampleSuccessWithSubtestsOtherTest.test_dummy",
       "status": "pass",
-      "test_code": "input_data = ['frog', 'fish', 'coconut', 'pineapple', 'carrot', 'cucumber', 'grass', 'tree']\nresult_data = [(\"Hello, World!\", param) for param in input_data]\nnumber_of_variants = range(1, len(input_data) + 1)\n\nfor variant, param, result in zip(number_of_variants, input_data, result_data):\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result,",
-      "task_id": 2
+      "test_code": "input_data = ['frog', 'fish', 'coconut', 'pineapple', 'carrot', 'cucumber', 'grass', 'tree']\nresult_data = [(\"Hello, World!\", param) for param in input_data]\nnumber_of_variants = range(1, len(input_data) + 1)\n\nfor variant, param, result in zip(number_of_variants, input_data, result_data):\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result,\n                         msg=f'Expected: {result} but got something else instead.')",
+      "task_id": 2,
+      "output": "User output is captured!\nUser output is captured!\nUser output is captured!\nUser output is captured!\nUser output is captured!\nUser output is captured!\nUser output is captured!\nUser output is captured!"
     },
     {
       "name": "ExampleSuccessWithSubtestsOtherTest.test_hello",
       "status": "pass",
-      "test_code": "input_data = [1, 2, 5, 10, 15, 23, 33, 39]\nresult_data = [(\"Hello, World!\", param) for param in input_data]\nnumber_of_variants = range(1, len(input_data) + 1)\n\nfor variant, param, result in zip(number_of_variants, input_data, result_data):\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result,",
-      "task_id": 2
+      "test_code": "input_data = [1, 2, 5, 10, 15, 23, 33, 39]\nresult_data = [(\"Hello, World!\", param) for param in input_data]\nnumber_of_variants = range(1, len(input_data) + 1)\n\nfor variant, param, result in zip(number_of_variants, input_data, result_data):\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result,\n                         msg=f'Expected: {result} but got something else instead.')",
+      "task_id": 2,
+      "output": "User output is captured!\nUser output is captured!\nUser output is captured!\nUser output is captured!\nUser output is captured!\nUser output is captured!\nUser output is captured!\nUser output is captured!"
     }
   ]
 }

--- a/test/example-syntax-error/results.json
+++ b/test/example-syntax-error/results.json
@@ -1,6 +1,6 @@
 {
   "version": 3,
   "status": "error",
-  "message": "  File \".solution.example_syntax_error.py\", line 3\n    def hello();\n               ^\nSyntaxError: invalid syntax",
+  "message": "  File \"./test/example-syntax-error/example_syntax_error.py\", line 3\n    def hello();\n               ^\nSyntaxError: invalid syntax",
   "tests": []
 }

--- a/test/example-syntax-error/results.json
+++ b/test/example-syntax-error/results.json
@@ -1,6 +1,6 @@
 {
   "version": 3,
   "status": "error",
-  "message": "  File \"./test/example-syntax-error/example_syntax_error.py\", line 3\n    def hello();\n               ^\nSyntaxError: invalid syntax",
+  "message": "  File \".solution.example_syntax_error.py\", line 3\n    def hello();\n               ^\nSyntaxError: invalid syntax",
   "tests": []
 }


### PR DESCRIPTION
Fixes #69

- Added `with` type to imports, and to the node check in `sort.py`, this then picks up/checks for `with` blocks/subtest blocks. 
- Added additional tests / test scenarios for task annotation and subtests
- Generated/re-generated `results.json` files to account for the runnter and test case scenario changes.