### PR TITLE
Change Test Report Sort Order and Make Test Names Website Friendly

### DIFF
--- a/runner/__init__.py
+++ b/runner/__init__.py
@@ -100,7 +100,7 @@ class ResultsReporter:
             # Changes status of parent to fail if any of the subtests fail.
             if state.fail:
                 self.tests[parent_test_name].fail(
-                    message="One or more subtests for this test failed. Details can be found under each variant."
+                    message="One or more variations of this test failed. Details can be found under each [variant#]."
                 )
                 self.tests[parent_test_name].test_code = state.test_code
 

--- a/runner/data.py
+++ b/runner/data.py
@@ -6,6 +6,7 @@ from enum import Enum, auto
 from json import JSONEncoder, dumps
 from typing import Any, List, NewType, Optional
 from pathlib import Path
+from re import compile, match, sub
 
 # an exercise slug, ie two-fer
 Slug = NewType("Slug", str)
@@ -153,6 +154,15 @@ class Results:
 
     def as_json(self):
         """
-        Dump the current Results to formatted JSON.
+        Trim off the TestClass name and test_ prefix from each test_name.
+        Replace underscores with spaces for more human-readable strings.
+        Sort the current tests array by task_id and then Dump all results to formatted JSON.
         """
-        return dumps(asdict(self, dict_factory=self._factory), indent=2)
+        trim_name = compile(r'^(.+)(Test\.test_)')
+        results = asdict(self, dict_factory=self._factory)
+
+        for item in results["tests"]:
+            item["name"] = sub(trim_name, '\\1 > ', item["name"]).replace('_', ' ')
+
+        results["tests"] = sorted(results["tests"], key= lambda item: item["task_id"])
+        return dumps(results, indent=2)

--- a/test/example-all-fail-tasks-and-subtests/results.json
+++ b/test/example-all-fail-tasks-and-subtests/results.json
@@ -3,196 +3,196 @@
   "status": "fail",
   "tests": [
     {
-      "name": "ExampleAllFailTest.test_abc",
+      "name": "ExampleAllFail > abc",
       "status": "fail",
-      "message": "One or more subtests for this test failed. Details can be found under each variant.",
+      "message": "One or more variations of this test failed. Details can be found under each [variant#].",
       "test_code": "input_data = ['frog', 'fish', 'coconut', 'pineapple', 'carrot', 'cucumber', 'grass', 'tree']\nresult_data = [(\"Hello, World!\", param) for param in input_data]\nnumber_of_variants = range(1, len(input_data) + 1)\n\nfor variant, param, result in zip(number_of_variants, input_data, result_data):\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result,\n                         msg=f'Expected: {result} but got something else instead.')",
       "task_id": 1
     },
     {
-      "name": "ExampleAllFailTest.test_hello",
+      "name": "ExampleAllFail > hello",
       "status": "fail",
-      "message": "One or more subtests for this test failed. Details can be found under each variant.",
+      "message": "One or more variations of this test failed. Details can be found under each [variant#].",
       "test_code": "input_data = [15, 23, 33, 39]\nresult_data = [(\"Hello, World!\", param) for param in input_data]\nnumber_of_variants = range(1, len(input_data) + 1)\n\nfor variant, param, result in zip(number_of_variants, input_data, result_data):\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result,\n                         msg=f'Expected: {result} but got something else instead.')",
       "task_id": 1
     },
     {
-      "name": "ExampleAllFailOtherTest.test_dummy",
-      "status": "fail",
-      "message": "One or more subtests for this test failed. Details can be found under each variant.",
-      "test_code": "input_data = ['frog', 'fish', 'coconut', 'pineapple', 'carrot', 'cucumber', 'grass', 'tree']\nresult_data = [(\"Hello, World!\", param) for param in input_data]\nnumber_of_variants = range(1, len(input_data) + 1)\n\nfor variant, param, result in zip(number_of_variants, input_data, result_data):\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result,\n                         msg=f'Expected: {result} but got something else instead.')",
-      "task_id": 2
-    },
-    {
-      "name": "ExampleAllFailOtherTest.test_hello",
-      "status": "fail",
-      "message": "One or more subtests for this test failed. Details can be found under each variant.",
-      "test_code": "input_data = [1, 2, 5, 10]\nresult_data = [(\"Hello, World!\", param) for param in input_data]\nnumber_of_variants = range(1, len(input_data) + 1)\n\nfor variant, param, result in zip(number_of_variants, input_data, result_data):\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result,\n                         msg=f'Expected: {result} but got something else instead.')",
-      "task_id": 2
-    },
-    {
-      "name": "ExampleAllFailTest.test_hello [variation #1] (param=15, result=('Hello, World!', 15))",
+      "name": "ExampleAllFail > hello [variation #1] (param=15, result=('Hello, World!', 15))",
       "status": "fail",
       "message": "AssertionError: 'Goodbye!' != ('Hello, World!', 15) : Expected: ('Hello, World!', 15) but got something else instead.",
       "test_code": "input_data = [15, 23, 33, 39]\nresult_data = [(\"Hello, World!\", param) for param in input_data]\nnumber_of_variants = range(1, len(input_data) + 1)\n\nfor variant, param, result in zip(number_of_variants, input_data, result_data):\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result,\n                         msg=f'Expected: {result} but got something else instead.')",
       "task_id": 1
     },
     {
-      "name": "ExampleAllFailTest.test_hello [variation #2] (param=23, result=('Hello, World!', 23))",
+      "name": "ExampleAllFail > hello [variation #2] (param=23, result=('Hello, World!', 23))",
       "status": "fail",
       "message": "AssertionError: 'Goodbye!' != ('Hello, World!', 23) : Expected: ('Hello, World!', 23) but got something else instead.",
       "test_code": "input_data = [15, 23, 33, 39]\nresult_data = [(\"Hello, World!\", param) for param in input_data]\nnumber_of_variants = range(1, len(input_data) + 1)\n\nfor variant, param, result in zip(number_of_variants, input_data, result_data):\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result,\n                         msg=f'Expected: {result} but got something else instead.')",
       "task_id": 1
     },
     {
-      "name": "ExampleAllFailTest.test_hello [variation #3] (param=33, result=('Hello, World!', 33))",
+      "name": "ExampleAllFail > hello [variation #3] (param=33, result=('Hello, World!', 33))",
       "status": "fail",
       "message": "AssertionError: 'Goodbye!' != ('Hello, World!', 33) : Expected: ('Hello, World!', 33) but got something else instead.",
       "test_code": "input_data = [15, 23, 33, 39]\nresult_data = [(\"Hello, World!\", param) for param in input_data]\nnumber_of_variants = range(1, len(input_data) + 1)\n\nfor variant, param, result in zip(number_of_variants, input_data, result_data):\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result,\n                         msg=f'Expected: {result} but got something else instead.')",
       "task_id": 1
     },
     {
-      "name": "ExampleAllFailTest.test_hello [variation #4] (param=39, result=('Hello, World!', 39))",
+      "name": "ExampleAllFail > hello [variation #4] (param=39, result=('Hello, World!', 39))",
       "status": "fail",
       "message": "AssertionError: 'Goodbye!' != ('Hello, World!', 39) : Expected: ('Hello, World!', 39) but got something else instead.",
       "test_code": "input_data = [15, 23, 33, 39]\nresult_data = [(\"Hello, World!\", param) for param in input_data]\nnumber_of_variants = range(1, len(input_data) + 1)\n\nfor variant, param, result in zip(number_of_variants, input_data, result_data):\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result,\n                         msg=f'Expected: {result} but got something else instead.')",
       "task_id": 1
     },
     {
-      "name": "ExampleAllFailTest.test_abc [variation #1] (param='frog', result=('Hello, World!', 'frog'))",
+      "name": "ExampleAllFail > abc [variation #1] (param='frog', result=('Hello, World!', 'frog'))",
       "status": "fail",
       "message": "AssertionError: 'Goodbye!' != ('Hello, World!', 'frog') : Expected: ('Hello, World!', 'frog') but got something else instead.",
       "test_code": "input_data = ['frog', 'fish', 'coconut', 'pineapple', 'carrot', 'cucumber', 'grass', 'tree']\nresult_data = [(\"Hello, World!\", param) for param in input_data]\nnumber_of_variants = range(1, len(input_data) + 1)\n\nfor variant, param, result in zip(number_of_variants, input_data, result_data):\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result,\n                         msg=f'Expected: {result} but got something else instead.')",
       "task_id": 1
     },
     {
-      "name": "ExampleAllFailTest.test_abc [variation #2] (param='fish', result=('Hello, World!', 'fish'))",
+      "name": "ExampleAllFail > abc [variation #2] (param='fish', result=('Hello, World!', 'fish'))",
       "status": "fail",
       "message": "AssertionError: 'Goodbye!' != ('Hello, World!', 'fish') : Expected: ('Hello, World!', 'fish') but got something else instead.",
       "test_code": "input_data = ['frog', 'fish', 'coconut', 'pineapple', 'carrot', 'cucumber', 'grass', 'tree']\nresult_data = [(\"Hello, World!\", param) for param in input_data]\nnumber_of_variants = range(1, len(input_data) + 1)\n\nfor variant, param, result in zip(number_of_variants, input_data, result_data):\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result,\n                         msg=f'Expected: {result} but got something else instead.')",
       "task_id": 1
     },
     {
-      "name": "ExampleAllFailTest.test_abc [variation #3] (param='coconut', result=('Hello, World!', 'coconut'))",
+      "name": "ExampleAllFail > abc [variation #3] (param='coconut', result=('Hello, World!', 'coconut'))",
       "status": "fail",
       "message": "AssertionError: 'Goodbye!' != ('Hello, World!', 'coconut') : Expected: ('Hello, World!', 'coconut') but got something else instead.",
       "test_code": "input_data = ['frog', 'fish', 'coconut', 'pineapple', 'carrot', 'cucumber', 'grass', 'tree']\nresult_data = [(\"Hello, World!\", param) for param in input_data]\nnumber_of_variants = range(1, len(input_data) + 1)\n\nfor variant, param, result in zip(number_of_variants, input_data, result_data):\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result,\n                         msg=f'Expected: {result} but got something else instead.')",
       "task_id": 1
     },
     {
-      "name": "ExampleAllFailTest.test_abc [variation #4] (param='pineapple', result=('Hello, World!', 'pineapple'))",
+      "name": "ExampleAllFail > abc [variation #4] (param='pineapple', result=('Hello, World!', 'pineapple'))",
       "status": "fail",
       "message": "AssertionError: 'Goodbye!' != ('Hello, World!', 'pineapple') : Expected: ('Hello, World!', 'pineapple') but got something else instead.",
       "test_code": "input_data = ['frog', 'fish', 'coconut', 'pineapple', 'carrot', 'cucumber', 'grass', 'tree']\nresult_data = [(\"Hello, World!\", param) for param in input_data]\nnumber_of_variants = range(1, len(input_data) + 1)\n\nfor variant, param, result in zip(number_of_variants, input_data, result_data):\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result,\n                         msg=f'Expected: {result} but got something else instead.')",
       "task_id": 1
     },
     {
-      "name": "ExampleAllFailTest.test_abc [variation #5] (param='carrot', result=('Hello, World!', 'carrot'))",
+      "name": "ExampleAllFail > abc [variation #5] (param='carrot', result=('Hello, World!', 'carrot'))",
       "status": "fail",
       "message": "AssertionError: 'Goodbye!' != ('Hello, World!', 'carrot') : Expected: ('Hello, World!', 'carrot') but got something else instead.",
       "test_code": "input_data = ['frog', 'fish', 'coconut', 'pineapple', 'carrot', 'cucumber', 'grass', 'tree']\nresult_data = [(\"Hello, World!\", param) for param in input_data]\nnumber_of_variants = range(1, len(input_data) + 1)\n\nfor variant, param, result in zip(number_of_variants, input_data, result_data):\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result,\n                         msg=f'Expected: {result} but got something else instead.')",
       "task_id": 1
     },
     {
-      "name": "ExampleAllFailTest.test_abc [variation #6] (param='cucumber', result=('Hello, World!', 'cucumber'))",
+      "name": "ExampleAllFail > abc [variation #6] (param='cucumber', result=('Hello, World!', 'cucumber'))",
       "status": "fail",
       "message": "AssertionError: 'Goodbye!' != ('Hello, World!', 'cucumber') : Expected: ('Hello, World!', 'cucumber') but got something else instead.",
       "test_code": "input_data = ['frog', 'fish', 'coconut', 'pineapple', 'carrot', 'cucumber', 'grass', 'tree']\nresult_data = [(\"Hello, World!\", param) for param in input_data]\nnumber_of_variants = range(1, len(input_data) + 1)\n\nfor variant, param, result in zip(number_of_variants, input_data, result_data):\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result,\n                         msg=f'Expected: {result} but got something else instead.')",
       "task_id": 1
     },
     {
-      "name": "ExampleAllFailTest.test_abc [variation #7] (param='grass', result=('Hello, World!', 'grass'))",
+      "name": "ExampleAllFail > abc [variation #7] (param='grass', result=('Hello, World!', 'grass'))",
       "status": "fail",
       "message": "AssertionError: 'Goodbye!' != ('Hello, World!', 'grass') : Expected: ('Hello, World!', 'grass') but got something else instead.",
       "test_code": "input_data = ['frog', 'fish', 'coconut', 'pineapple', 'carrot', 'cucumber', 'grass', 'tree']\nresult_data = [(\"Hello, World!\", param) for param in input_data]\nnumber_of_variants = range(1, len(input_data) + 1)\n\nfor variant, param, result in zip(number_of_variants, input_data, result_data):\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result,\n                         msg=f'Expected: {result} but got something else instead.')",
       "task_id": 1
     },
     {
-      "name": "ExampleAllFailTest.test_abc [variation #8] (param='tree', result=('Hello, World!', 'tree'))",
+      "name": "ExampleAllFail > abc [variation #8] (param='tree', result=('Hello, World!', 'tree'))",
       "status": "fail",
       "message": "AssertionError: 'Goodbye!' != ('Hello, World!', 'tree') : Expected: ('Hello, World!', 'tree') but got something else instead.",
       "test_code": "input_data = ['frog', 'fish', 'coconut', 'pineapple', 'carrot', 'cucumber', 'grass', 'tree']\nresult_data = [(\"Hello, World!\", param) for param in input_data]\nnumber_of_variants = range(1, len(input_data) + 1)\n\nfor variant, param, result in zip(number_of_variants, input_data, result_data):\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result,\n                         msg=f'Expected: {result} but got something else instead.')",
       "task_id": 1
     },
     {
-      "name": "ExampleAllFailOtherTest.test_dummy [variation #1] (param='frog', result=('Hello, World!', 'frog'))",
+      "name": "ExampleAllFailOther > dummy",
+      "status": "fail",
+      "message": "One or more variations of this test failed. Details can be found under each [variant#].",
+      "test_code": "input_data = ['frog', 'fish', 'coconut', 'pineapple', 'carrot', 'cucumber', 'grass', 'tree']\nresult_data = [(\"Hello, World!\", param) for param in input_data]\nnumber_of_variants = range(1, len(input_data) + 1)\n\nfor variant, param, result in zip(number_of_variants, input_data, result_data):\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result,\n                         msg=f'Expected: {result} but got something else instead.')",
+      "task_id": 2
+    },
+    {
+      "name": "ExampleAllFailOther > hello",
+      "status": "fail",
+      "message": "One or more variations of this test failed. Details can be found under each [variant#].",
+      "test_code": "input_data = [1, 2, 5, 10]\nresult_data = [(\"Hello, World!\", param) for param in input_data]\nnumber_of_variants = range(1, len(input_data) + 1)\n\nfor variant, param, result in zip(number_of_variants, input_data, result_data):\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result,\n                         msg=f'Expected: {result} but got something else instead.')",
+      "task_id": 2
+    },
+    {
+      "name": "ExampleAllFailOther > dummy [variation #1] (param='frog', result=('Hello, World!', 'frog'))",
       "status": "fail",
       "message": "AssertionError: 'Goodbye!' != ('Hello, World!', 'frog') : Expected: ('Hello, World!', 'frog') but got something else instead.",
       "test_code": "input_data = ['frog', 'fish', 'coconut', 'pineapple', 'carrot', 'cucumber', 'grass', 'tree']\nresult_data = [(\"Hello, World!\", param) for param in input_data]\nnumber_of_variants = range(1, len(input_data) + 1)\n\nfor variant, param, result in zip(number_of_variants, input_data, result_data):\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result,\n                         msg=f'Expected: {result} but got something else instead.')",
       "task_id": 2
     },
     {
-      "name": "ExampleAllFailOtherTest.test_dummy [variation #2] (param='fish', result=('Hello, World!', 'fish'))",
+      "name": "ExampleAllFailOther > dummy [variation #2] (param='fish', result=('Hello, World!', 'fish'))",
       "status": "fail",
       "message": "AssertionError: 'Goodbye!' != ('Hello, World!', 'fish') : Expected: ('Hello, World!', 'fish') but got something else instead.",
       "test_code": "input_data = ['frog', 'fish', 'coconut', 'pineapple', 'carrot', 'cucumber', 'grass', 'tree']\nresult_data = [(\"Hello, World!\", param) for param in input_data]\nnumber_of_variants = range(1, len(input_data) + 1)\n\nfor variant, param, result in zip(number_of_variants, input_data, result_data):\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result,\n                         msg=f'Expected: {result} but got something else instead.')",
       "task_id": 2
     },
     {
-      "name": "ExampleAllFailOtherTest.test_dummy [variation #3] (param='coconut', result=('Hello, World!', 'coconut'))",
+      "name": "ExampleAllFailOther > dummy [variation #3] (param='coconut', result=('Hello, World!', 'coconut'))",
       "status": "fail",
       "message": "AssertionError: 'Goodbye!' != ('Hello, World!', 'coconut') : Expected: ('Hello, World!', 'coconut') but got something else instead.",
       "test_code": "input_data = ['frog', 'fish', 'coconut', 'pineapple', 'carrot', 'cucumber', 'grass', 'tree']\nresult_data = [(\"Hello, World!\", param) for param in input_data]\nnumber_of_variants = range(1, len(input_data) + 1)\n\nfor variant, param, result in zip(number_of_variants, input_data, result_data):\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result,\n                         msg=f'Expected: {result} but got something else instead.')",
       "task_id": 2
     },
     {
-      "name": "ExampleAllFailOtherTest.test_dummy [variation #4] (param='pineapple', result=('Hello, World!', 'pineapple'))",
+      "name": "ExampleAllFailOther > dummy [variation #4] (param='pineapple', result=('Hello, World!', 'pineapple'))",
       "status": "fail",
       "message": "AssertionError: 'Goodbye!' != ('Hello, World!', 'pineapple') : Expected: ('Hello, World!', 'pineapple') but got something else instead.",
       "test_code": "input_data = ['frog', 'fish', 'coconut', 'pineapple', 'carrot', 'cucumber', 'grass', 'tree']\nresult_data = [(\"Hello, World!\", param) for param in input_data]\nnumber_of_variants = range(1, len(input_data) + 1)\n\nfor variant, param, result in zip(number_of_variants, input_data, result_data):\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result,\n                         msg=f'Expected: {result} but got something else instead.')",
       "task_id": 2
     },
     {
-      "name": "ExampleAllFailOtherTest.test_dummy [variation #5] (param='carrot', result=('Hello, World!', 'carrot'))",
+      "name": "ExampleAllFailOther > dummy [variation #5] (param='carrot', result=('Hello, World!', 'carrot'))",
       "status": "fail",
       "message": "AssertionError: 'Goodbye!' != ('Hello, World!', 'carrot') : Expected: ('Hello, World!', 'carrot') but got something else instead.",
       "test_code": "input_data = ['frog', 'fish', 'coconut', 'pineapple', 'carrot', 'cucumber', 'grass', 'tree']\nresult_data = [(\"Hello, World!\", param) for param in input_data]\nnumber_of_variants = range(1, len(input_data) + 1)\n\nfor variant, param, result in zip(number_of_variants, input_data, result_data):\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result,\n                         msg=f'Expected: {result} but got something else instead.')",
       "task_id": 2
     },
     {
-      "name": "ExampleAllFailOtherTest.test_dummy [variation #6] (param='cucumber', result=('Hello, World!', 'cucumber'))",
+      "name": "ExampleAllFailOther > dummy [variation #6] (param='cucumber', result=('Hello, World!', 'cucumber'))",
       "status": "fail",
       "message": "AssertionError: 'Goodbye!' != ('Hello, World!', 'cucumber') : Expected: ('Hello, World!', 'cucumber') but got something else instead.",
       "test_code": "input_data = ['frog', 'fish', 'coconut', 'pineapple', 'carrot', 'cucumber', 'grass', 'tree']\nresult_data = [(\"Hello, World!\", param) for param in input_data]\nnumber_of_variants = range(1, len(input_data) + 1)\n\nfor variant, param, result in zip(number_of_variants, input_data, result_data):\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result,\n                         msg=f'Expected: {result} but got something else instead.')",
       "task_id": 2
     },
     {
-      "name": "ExampleAllFailOtherTest.test_dummy [variation #7] (param='grass', result=('Hello, World!', 'grass'))",
+      "name": "ExampleAllFailOther > dummy [variation #7] (param='grass', result=('Hello, World!', 'grass'))",
       "status": "fail",
       "message": "AssertionError: 'Goodbye!' != ('Hello, World!', 'grass') : Expected: ('Hello, World!', 'grass') but got something else instead.",
       "test_code": "input_data = ['frog', 'fish', 'coconut', 'pineapple', 'carrot', 'cucumber', 'grass', 'tree']\nresult_data = [(\"Hello, World!\", param) for param in input_data]\nnumber_of_variants = range(1, len(input_data) + 1)\n\nfor variant, param, result in zip(number_of_variants, input_data, result_data):\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result,\n                         msg=f'Expected: {result} but got something else instead.')",
       "task_id": 2
     },
     {
-      "name": "ExampleAllFailOtherTest.test_dummy [variation #8] (param='tree', result=('Hello, World!', 'tree'))",
+      "name": "ExampleAllFailOther > dummy [variation #8] (param='tree', result=('Hello, World!', 'tree'))",
       "status": "fail",
       "message": "AssertionError: 'Goodbye!' != ('Hello, World!', 'tree') : Expected: ('Hello, World!', 'tree') but got something else instead.",
       "test_code": "input_data = ['frog', 'fish', 'coconut', 'pineapple', 'carrot', 'cucumber', 'grass', 'tree']\nresult_data = [(\"Hello, World!\", param) for param in input_data]\nnumber_of_variants = range(1, len(input_data) + 1)\n\nfor variant, param, result in zip(number_of_variants, input_data, result_data):\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result,\n                         msg=f'Expected: {result} but got something else instead.')",
       "task_id": 2
     },
     {
-      "name": "ExampleAllFailOtherTest.test_hello [variation #1] (param=1, result=('Hello, World!', 1))",
+      "name": "ExampleAllFailOther > hello [variation #1] (param=1, result=('Hello, World!', 1))",
       "status": "fail",
       "message": "AssertionError: 'Goodbye!' != ('Hello, World!', 1) : Expected: ('Hello, World!', 1) but got something else instead.",
       "test_code": "input_data = [1, 2, 5, 10]\nresult_data = [(\"Hello, World!\", param) for param in input_data]\nnumber_of_variants = range(1, len(input_data) + 1)\n\nfor variant, param, result in zip(number_of_variants, input_data, result_data):\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result,\n                         msg=f'Expected: {result} but got something else instead.')",
       "task_id": 2
     },
     {
-      "name": "ExampleAllFailOtherTest.test_hello [variation #2] (param=2, result=('Hello, World!', 2))",
+      "name": "ExampleAllFailOther > hello [variation #2] (param=2, result=('Hello, World!', 2))",
       "status": "fail",
       "message": "AssertionError: 'Goodbye!' != ('Hello, World!', 2) : Expected: ('Hello, World!', 2) but got something else instead.",
       "test_code": "input_data = [1, 2, 5, 10]\nresult_data = [(\"Hello, World!\", param) for param in input_data]\nnumber_of_variants = range(1, len(input_data) + 1)\n\nfor variant, param, result in zip(number_of_variants, input_data, result_data):\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result,\n                         msg=f'Expected: {result} but got something else instead.')",
       "task_id": 2
     },
     {
-      "name": "ExampleAllFailOtherTest.test_hello [variation #3] (param=5, result=('Hello, World!', 5))",
+      "name": "ExampleAllFailOther > hello [variation #3] (param=5, result=('Hello, World!', 5))",
       "status": "fail",
       "message": "AssertionError: 'Goodbye!' != ('Hello, World!', 5) : Expected: ('Hello, World!', 5) but got something else instead.",
       "test_code": "input_data = [1, 2, 5, 10]\nresult_data = [(\"Hello, World!\", param) for param in input_data]\nnumber_of_variants = range(1, len(input_data) + 1)\n\nfor variant, param, result in zip(number_of_variants, input_data, result_data):\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result,\n                         msg=f'Expected: {result} but got something else instead.')",
       "task_id": 2
     },
     {
-      "name": "ExampleAllFailOtherTest.test_hello [variation #4] (param=10, result=('Hello, World!', 10))",
+      "name": "ExampleAllFailOther > hello [variation #4] (param=10, result=('Hello, World!', 10))",
       "status": "fail",
       "message": "AssertionError: 'Goodbye!' != ('Hello, World!', 10) : Expected: ('Hello, World!', 10) but got something else instead.",
       "test_code": "input_data = [1, 2, 5, 10]\nresult_data = [(\"Hello, World!\", param) for param in input_data]\nnumber_of_variants = range(1, len(input_data) + 1)\n\nfor variant, param, result in zip(number_of_variants, input_data, result_data):\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result,\n                         msg=f'Expected: {result} but got something else instead.')",

--- a/test/example-all-fail/results.json
+++ b/test/example-all-fail/results.json
@@ -3,28 +3,28 @@
   "status": "fail",
   "tests": [
     {
-      "name": "ExampleAllFailTest.test_hello",
+      "name": "ExampleAllFail > hello",
       "status": "fail",
       "message": "AssertionError: 'Goodbye!' != 'Hello, World!'\n- Goodbye!\n+ Hello, World!",
       "test_code": "self.assertEqual(hello(), \"Hello, World!\")",
       "task_id": 0
     },
     {
-      "name": "ExampleAllFailTest.test_abc",
+      "name": "ExampleAllFail > abc",
       "status": "fail",
       "message": "AssertionError: 'Goodbye!' != 'Hello, World!'\n- Goodbye!\n+ Hello, World!",
       "test_code": "self.assertEqual(hello(), \"Hello, World!\")",
       "task_id": 0
     },
     {
-      "name": "ExampleAllFailOtherTest.test_dummy",
+      "name": "ExampleAllFailOther > dummy",
       "status": "fail",
       "message": "AssertionError: 'Goodbye!' != 'Hello, World!'\n- Goodbye!\n+ Hello, World!",
       "test_code": "self.assertEqual(hello(), \"Hello, World!\")",
       "task_id": 0
     },
     {
-      "name": "ExampleAllFailOtherTest.test_hello",
+      "name": "ExampleAllFailOther > hello",
       "status": "fail",
       "message": "AssertionError: 'Goodbye!' != 'Hello, World!'\n- Goodbye!\n+ Hello, World!",
       "test_code": "self.assertEqual(hello(), \"Hello, World!\")",

--- a/test/example-config-multiple-files-subtests-and-tasks/results.json
+++ b/test/example-config-multiple-files-subtests-and-tasks/results.json
@@ -3,56 +3,56 @@
   "status": "pass",
   "tests": [
     {
-      "name": "ExampleFirstTest.test_abc",
+      "name": "ExampleFirst > abc",
       "status": "pass",
       "test_code": "self.assertEqual(hello(13), (\"Hello, World!\", 13))",
       "task_id": 1,
       "output": "User output is captured! 13"
     },
     {
-      "name": "ExampleFirstTest.test_hello",
+      "name": "ExampleFirst > hello",
       "status": "pass",
       "test_code": "self.assertEqual(hello('Hi'), (\"Hello, World!\", 'Hi'))",
       "task_id": 1,
       "output": "User output is captured! Hi"
     },
     {
-      "name": "ExampleFirstOtherTest.test_dummy",
+      "name": "ExampleFirstOther > dummy",
       "status": "pass",
       "test_code": "self.assertEqual(hello('Banana'), (\"Hello, World!\", \"Banana\"))",
       "task_id": 2,
       "output": "User output is captured! Banana"
     },
     {
-      "name": "ExampleFirstOtherTest.test_hello",
+      "name": "ExampleFirstOther > hello",
       "status": "pass",
       "test_code": "self.assertEqual(hello(42), (\"Hello, World!\", 42))",
       "task_id": 2,
       "output": "User output is captured! 42"
     },
     {
-      "name": "ExampleSecondTest.test_abc",
+      "name": "ExampleSecond > abc",
       "status": "pass",
       "test_code": "input_data = ['carrot', 'cucumber', 'grass', 'tree']\nresult_data = [(\"Hello, World!\", param) for param in input_data]\nnumber_of_variants = range(1, len(input_data) + 1)\n\nfor variant, param, result in zip(number_of_variants, input_data, result_data):\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result,\n                         msg=f'Expected: {result} but got something else instead.')",
       "task_id": 3,
       "output": "User output is captured! carrot\nUser output is captured! cucumber\nUser output is captured! grass\nUser output is captured! tree"
     },
     {
-      "name": "ExampleSecondTest.test_hello",
+      "name": "ExampleSecond > hello",
       "status": "pass",
       "test_code": "input_data = [1, 2, 5]\nresult_data = [(\"Hello, World!\", param) for param in input_data]\nnumber_of_variants = range(1, len(input_data) + 1)\n\nfor variant, param, result in zip(number_of_variants, input_data, result_data):\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result,\n                         msg=f'Expected: {result} but got something else instead.')",
       "task_id": 3,
       "output": "User output is captured! 1\nUser output is captured! 2\nUser output is captured! 5"
     },
     {
-      "name": "ExampleSecondOtherTest.test_dummy",
+      "name": "ExampleSecondOther > dummy",
       "status": "pass",
       "test_code": "input_data = ['frog', 'fish', 'coconut']\nresult_data = [(\"Hello, World!\", param) for param in input_data]\nnumber_of_variants = range(1, len(input_data) + 1)\n\nfor variant, param, result in zip(number_of_variants, input_data, result_data):\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result,\n                         msg=f'Expected: {result} but got something else instead.')",
       "task_id": 4,
       "output": "User output is captured! frog\nUser output is captured! fish\nUser output is captured! coconut"
     },
     {
-      "name": "ExampleSecondOtherTest.test_hello",
+      "name": "ExampleSecondOther > hello",
       "status": "pass",
       "test_code": "input_data = [23, 33, 39]\nresult_data = [(\"Hello, World!\", param) for param in input_data]\nnumber_of_variants = range(1, len(input_data) + 1)\n\nfor variant, param, result in zip(number_of_variants, input_data, result_data):\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result,\n                         msg=f'Expected: {result} but got something else instead.')",
       "task_id": 4,

--- a/test/example-empty-file/results.json
+++ b/test/example-empty-file/results.json
@@ -1,6 +1,6 @@
 {
   "version": 3,
   "status": "error",
-  "message": "ImportError: cannot import name 'hello' from 'example_empty_file' (./test/example-empty-file/example_empty_file.py)",
+  "message": "ImportError: cannot import name 'hello' from 'example_empty_file' (.solution.example_empty_file.py)",
   "tests": []
 }

--- a/test/example-empty-file/results.json
+++ b/test/example-empty-file/results.json
@@ -1,6 +1,6 @@
 {
   "version": 3,
   "status": "error",
-  "message": "ImportError: cannot import name 'hello' from 'example_empty_file' (.solution.example_empty_file.py)",
+  "message": "ImportError: cannot import name 'hello' from 'example_empty_file' (./test/example-empty-file/example_empty_file.py)",
   "tests": []
 }

--- a/test/example-has-stdout-and-tasks/results.json
+++ b/test/example-has-stdout-and-tasks/results.json
@@ -3,15 +3,7 @@
   "status": "fail",
   "tests": [
     {
-      "name": "ExampleHasStdoutAndTasksTest.test_abc",
-      "status": "fail",
-      "message": "AssertionError: None != 'Hello, World!'",
-      "test_code": "self.assertEqual(hello(), \"Hello, World!\")",
-      "task_id": 2,
-      "output": "Hello, World!"
-    },
-    {
-      "name": "ExampleHasStdoutAndTasksTest.test_hello",
+      "name": "ExampleHasStdoutAndTasks > hello",
       "status": "fail",
       "message": "AssertionError: None != 'Hello, World!'",
       "test_code": "self.assertEqual(hello(), \"Hello, World!\")",
@@ -19,7 +11,15 @@
       "output": "Hello, World!"
     },
     {
-      "name": "ExampleHasStdoutAndTasksTest.test_trancation",
+      "name": "ExampleHasStdoutAndTasks > abc",
+      "status": "fail",
+      "message": "AssertionError: None != 'Hello, World!'",
+      "test_code": "self.assertEqual(hello(), \"Hello, World!\")",
+      "task_id": 2,
+      "output": "Hello, World!"
+    },
+    {
+      "name": "ExampleHasStdoutAndTasks > trancation",
       "status": "fail",
       "message": "AssertionError: 'Goodbye!' != 'Hello, World!'\n- Goodbye!\n+ Hello, World!",
       "test_code": "self.assertEqual(must_truncate(), \"Hello, World!\")",
@@ -27,7 +27,7 @@
       "output": "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Vulputate ut pharetra sit amet aliquam. Amet dictum sit amet justo donec enim diam vulputate ut. Consequat nisl vel pretium lectus quam id leo. Maecenas accumsan lacus vel facilisis volutpat est velit egestas dui. Faucibus et molestie ac feugiat sed. Fringilla phasellus faucibus scelerisque eleifend donec pretium vulputate s [Output was truncated. Please limit to 500 chars]"
     },
     {
-      "name": "ExampleHasStdoutAndTasksOtherTest.test_dummy",
+      "name": "ExampleHasStdoutAndTasksOther > dummy",
       "status": "fail",
       "message": "AssertionError: None != 'Hello, World!'",
       "test_code": "self.assertEqual(hello(), \"Hello, World!\")",
@@ -35,7 +35,7 @@
       "output": "Hello, World!"
     },
     {
-      "name": "ExampleHasStdoutAndTasksOtherTest.test_hello",
+      "name": "ExampleHasStdoutAndTasksOther > hello",
       "status": "fail",
       "message": "AssertionError: None != 'Hello, World!'",
       "test_code": "self.assertEqual(hello(), \"Hello, World!\")",

--- a/test/example-has-stdout-tasks-and-subtests/results.json
+++ b/test/example-has-stdout-tasks-and-subtests/results.json
@@ -3,21 +3,133 @@
   "status": "fail",
   "tests": [
     {
-      "name": "ExampleHasStdoutTest.test_abc",
+      "name": "ExampleHasStdout > hello",
       "status": "fail",
-      "message": "One or more subtests for this test failed. Details can be found under each variant.",
-      "test_code": "input_data = ['frog', 'fish', 'coconut', 'pineapple', 'carrot', 'cucumber', 'grass', 'tree']\nresult_data = [(\"Hello, World!\", param) for param in input_data]\nnumber_of_variants = range(1, len(input_data) + 1)\n\nfor variant, param, result in zip(number_of_variants, input_data, result_data):\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result,\n                         msg=f'Expected: {result} but got something else instead.')",
-      "task_id": 2
-    },
-    {
-      "name": "ExampleHasStdoutTest.test_hello",
-      "status": "fail",
-      "message": "One or more subtests for this test failed. Details can be found under each variant.",
+      "message": "One or more variations of this test failed. Details can be found under each [variant#].",
       "test_code": "input_data = [1, 2, 5, 10, 15, 23, 33, 39]\nresult_data = [(\"Hello, World!\", param) for param in input_data]\nnumber_of_variants = range(1, len(input_data) + 1)\n\nfor variant, param, result in zip(number_of_variants, input_data, result_data):\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result,\n                         msg=f'Expected: {result} but got something else instead.')",
       "task_id": 1
     },
     {
-      "name": "ExampleHasStdoutTest.test_truncation",
+      "name": "ExampleHasStdout > hello [variation #1] (param=1, result=('Hello, World!', 1))",
+      "status": "fail",
+      "message": "AssertionError: None != ('Hello, World!', 1) : Expected: ('Hello, World!', 1) but got something else instead.",
+      "test_code": "input_data = [1, 2, 5, 10, 15, 23, 33, 39]\nresult_data = [(\"Hello, World!\", param) for param in input_data]\nnumber_of_variants = range(1, len(input_data) + 1)\n\nfor variant, param, result in zip(number_of_variants, input_data, result_data):\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result,\n                         msg=f'Expected: {result} but got something else instead.')",
+      "task_id": 1
+    },
+    {
+      "name": "ExampleHasStdout > hello [variation #2] (param=2, result=('Hello, World!', 2))",
+      "status": "fail",
+      "message": "AssertionError: None != ('Hello, World!', 2) : Expected: ('Hello, World!', 2) but got something else instead.",
+      "test_code": "input_data = [1, 2, 5, 10, 15, 23, 33, 39]\nresult_data = [(\"Hello, World!\", param) for param in input_data]\nnumber_of_variants = range(1, len(input_data) + 1)\n\nfor variant, param, result in zip(number_of_variants, input_data, result_data):\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result,\n                         msg=f'Expected: {result} but got something else instead.')",
+      "task_id": 1
+    },
+    {
+      "name": "ExampleHasStdout > hello [variation #3] (param=5, result=('Hello, World!', 5))",
+      "status": "fail",
+      "message": "AssertionError: None != ('Hello, World!', 5) : Expected: ('Hello, World!', 5) but got something else instead.",
+      "test_code": "input_data = [1, 2, 5, 10, 15, 23, 33, 39]\nresult_data = [(\"Hello, World!\", param) for param in input_data]\nnumber_of_variants = range(1, len(input_data) + 1)\n\nfor variant, param, result in zip(number_of_variants, input_data, result_data):\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result,\n                         msg=f'Expected: {result} but got something else instead.')",
+      "task_id": 1
+    },
+    {
+      "name": "ExampleHasStdout > hello [variation #4] (param=10, result=('Hello, World!', 10))",
+      "status": "fail",
+      "message": "AssertionError: None != ('Hello, World!', 10) : Expected: ('Hello, World!', 10) but got something else instead.",
+      "test_code": "input_data = [1, 2, 5, 10, 15, 23, 33, 39]\nresult_data = [(\"Hello, World!\", param) for param in input_data]\nnumber_of_variants = range(1, len(input_data) + 1)\n\nfor variant, param, result in zip(number_of_variants, input_data, result_data):\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result,\n                         msg=f'Expected: {result} but got something else instead.')",
+      "task_id": 1
+    },
+    {
+      "name": "ExampleHasStdout > hello [variation #5] (param=15, result=('Hello, World!', 15))",
+      "status": "fail",
+      "message": "AssertionError: None != ('Hello, World!', 15) : Expected: ('Hello, World!', 15) but got something else instead.",
+      "test_code": "input_data = [1, 2, 5, 10, 15, 23, 33, 39]\nresult_data = [(\"Hello, World!\", param) for param in input_data]\nnumber_of_variants = range(1, len(input_data) + 1)\n\nfor variant, param, result in zip(number_of_variants, input_data, result_data):\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result,\n                         msg=f'Expected: {result} but got something else instead.')",
+      "task_id": 1
+    },
+    {
+      "name": "ExampleHasStdout > hello [variation #6] (param=23, result=('Hello, World!', 23))",
+      "status": "fail",
+      "message": "AssertionError: None != ('Hello, World!', 23) : Expected: ('Hello, World!', 23) but got something else instead.",
+      "test_code": "input_data = [1, 2, 5, 10, 15, 23, 33, 39]\nresult_data = [(\"Hello, World!\", param) for param in input_data]\nnumber_of_variants = range(1, len(input_data) + 1)\n\nfor variant, param, result in zip(number_of_variants, input_data, result_data):\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result,\n                         msg=f'Expected: {result} but got something else instead.')",
+      "task_id": 1
+    },
+    {
+      "name": "ExampleHasStdout > hello [variation #7] (param=33, result=('Hello, World!', 33))",
+      "status": "fail",
+      "message": "AssertionError: None != ('Hello, World!', 33) : Expected: ('Hello, World!', 33) but got something else instead.",
+      "test_code": "input_data = [1, 2, 5, 10, 15, 23, 33, 39]\nresult_data = [(\"Hello, World!\", param) for param in input_data]\nnumber_of_variants = range(1, len(input_data) + 1)\n\nfor variant, param, result in zip(number_of_variants, input_data, result_data):\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result,\n                         msg=f'Expected: {result} but got something else instead.')",
+      "task_id": 1
+    },
+    {
+      "name": "ExampleHasStdout > hello [variation #8] (param=39, result=('Hello, World!', 39))",
+      "status": "fail",
+      "message": "AssertionError: None != ('Hello, World!', 39) : Expected: ('Hello, World!', 39) but got something else instead.",
+      "test_code": "input_data = [1, 2, 5, 10, 15, 23, 33, 39]\nresult_data = [(\"Hello, World!\", param) for param in input_data]\nnumber_of_variants = range(1, len(input_data) + 1)\n\nfor variant, param, result in zip(number_of_variants, input_data, result_data):\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result,\n                         msg=f'Expected: {result} but got something else instead.')",
+      "task_id": 1
+    },
+    {
+      "name": "ExampleHasStdout > abc",
+      "status": "fail",
+      "message": "One or more variations of this test failed. Details can be found under each [variant#].",
+      "test_code": "input_data = ['frog', 'fish', 'coconut', 'pineapple', 'carrot', 'cucumber', 'grass', 'tree']\nresult_data = [(\"Hello, World!\", param) for param in input_data]\nnumber_of_variants = range(1, len(input_data) + 1)\n\nfor variant, param, result in zip(number_of_variants, input_data, result_data):\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result,\n                         msg=f'Expected: {result} but got something else instead.')",
+      "task_id": 2
+    },
+    {
+      "name": "ExampleHasStdout > abc [variation #1] (param='frog', result=('Hello, World!', 'frog'))",
+      "status": "fail",
+      "message": "AssertionError: None != ('Hello, World!', 'frog') : Expected: ('Hello, World!', 'frog') but got something else instead.",
+      "test_code": "input_data = ['frog', 'fish', 'coconut', 'pineapple', 'carrot', 'cucumber', 'grass', 'tree']\nresult_data = [(\"Hello, World!\", param) for param in input_data]\nnumber_of_variants = range(1, len(input_data) + 1)\n\nfor variant, param, result in zip(number_of_variants, input_data, result_data):\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result,\n                         msg=f'Expected: {result} but got something else instead.')",
+      "task_id": 2
+    },
+    {
+      "name": "ExampleHasStdout > abc [variation #2] (param='fish', result=('Hello, World!', 'fish'))",
+      "status": "fail",
+      "message": "AssertionError: None != ('Hello, World!', 'fish') : Expected: ('Hello, World!', 'fish') but got something else instead.",
+      "test_code": "input_data = ['frog', 'fish', 'coconut', 'pineapple', 'carrot', 'cucumber', 'grass', 'tree']\nresult_data = [(\"Hello, World!\", param) for param in input_data]\nnumber_of_variants = range(1, len(input_data) + 1)\n\nfor variant, param, result in zip(number_of_variants, input_data, result_data):\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result,\n                         msg=f'Expected: {result} but got something else instead.')",
+      "task_id": 2
+    },
+    {
+      "name": "ExampleHasStdout > abc [variation #3] (param='coconut', result=('Hello, World!', 'coconut'))",
+      "status": "fail",
+      "message": "AssertionError: None != ('Hello, World!', 'coconut') : Expected: ('Hello, World!', 'coconut') but got something else instead.",
+      "test_code": "input_data = ['frog', 'fish', 'coconut', 'pineapple', 'carrot', 'cucumber', 'grass', 'tree']\nresult_data = [(\"Hello, World!\", param) for param in input_data]\nnumber_of_variants = range(1, len(input_data) + 1)\n\nfor variant, param, result in zip(number_of_variants, input_data, result_data):\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result,\n                         msg=f'Expected: {result} but got something else instead.')",
+      "task_id": 2
+    },
+    {
+      "name": "ExampleHasStdout > abc [variation #4] (param='pineapple', result=('Hello, World!', 'pineapple'))",
+      "status": "fail",
+      "message": "AssertionError: None != ('Hello, World!', 'pineapple') : Expected: ('Hello, World!', 'pineapple') but got something else instead.",
+      "test_code": "input_data = ['frog', 'fish', 'coconut', 'pineapple', 'carrot', 'cucumber', 'grass', 'tree']\nresult_data = [(\"Hello, World!\", param) for param in input_data]\nnumber_of_variants = range(1, len(input_data) + 1)\n\nfor variant, param, result in zip(number_of_variants, input_data, result_data):\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result,\n                         msg=f'Expected: {result} but got something else instead.')",
+      "task_id": 2
+    },
+    {
+      "name": "ExampleHasStdout > abc [variation #5] (param='carrot', result=('Hello, World!', 'carrot'))",
+      "status": "fail",
+      "message": "AssertionError: None != ('Hello, World!', 'carrot') : Expected: ('Hello, World!', 'carrot') but got something else instead.",
+      "test_code": "input_data = ['frog', 'fish', 'coconut', 'pineapple', 'carrot', 'cucumber', 'grass', 'tree']\nresult_data = [(\"Hello, World!\", param) for param in input_data]\nnumber_of_variants = range(1, len(input_data) + 1)\n\nfor variant, param, result in zip(number_of_variants, input_data, result_data):\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result,\n                         msg=f'Expected: {result} but got something else instead.')",
+      "task_id": 2
+    },
+    {
+      "name": "ExampleHasStdout > abc [variation #6] (param='cucumber', result=('Hello, World!', 'cucumber'))",
+      "status": "fail",
+      "message": "AssertionError: None != ('Hello, World!', 'cucumber') : Expected: ('Hello, World!', 'cucumber') but got something else instead.",
+      "test_code": "input_data = ['frog', 'fish', 'coconut', 'pineapple', 'carrot', 'cucumber', 'grass', 'tree']\nresult_data = [(\"Hello, World!\", param) for param in input_data]\nnumber_of_variants = range(1, len(input_data) + 1)\n\nfor variant, param, result in zip(number_of_variants, input_data, result_data):\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result,\n                         msg=f'Expected: {result} but got something else instead.')",
+      "task_id": 2
+    },
+    {
+      "name": "ExampleHasStdout > abc [variation #7] (param='grass', result=('Hello, World!', 'grass'))",
+      "status": "fail",
+      "message": "AssertionError: None != ('Hello, World!', 'grass') : Expected: ('Hello, World!', 'grass') but got something else instead.",
+      "test_code": "input_data = ['frog', 'fish', 'coconut', 'pineapple', 'carrot', 'cucumber', 'grass', 'tree']\nresult_data = [(\"Hello, World!\", param) for param in input_data]\nnumber_of_variants = range(1, len(input_data) + 1)\n\nfor variant, param, result in zip(number_of_variants, input_data, result_data):\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result,\n                         msg=f'Expected: {result} but got something else instead.')",
+      "task_id": 2
+    },
+    {
+      "name": "ExampleHasStdout > abc [variation #8] (param='tree', result=('Hello, World!', 'tree'))",
+      "status": "fail",
+      "message": "AssertionError: None != ('Hello, World!', 'tree') : Expected: ('Hello, World!', 'tree') but got something else instead.",
+      "test_code": "input_data = ['frog', 'fish', 'coconut', 'pineapple', 'carrot', 'cucumber', 'grass', 'tree']\nresult_data = [(\"Hello, World!\", param) for param in input_data]\nnumber_of_variants = range(1, len(input_data) + 1)\n\nfor variant, param, result in zip(number_of_variants, input_data, result_data):\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result,\n                         msg=f'Expected: {result} but got something else instead.')",
+      "task_id": 2
+    },
+    {
+      "name": "ExampleHasStdout > truncation",
       "status": "fail",
       "message": "AssertionError: 'Goodbye!' != 'Hello, World!'\n- Goodbye!\n+ Hello, World!",
       "test_code": "self.assertEqual(must_truncate(), \"Hello, World!\")",
@@ -25,238 +137,126 @@
       "output": "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Vulputate ut pharetra sit amet aliquam. Amet dictum sit amet justo donec enim diam vulputate ut. Consequat nisl vel pretium lectus quam id leo. Maecenas accumsan lacus vel facilisis volutpat est velit egestas dui. Faucibus et molestie ac feugiat sed. Fringilla phasellus faucibus scelerisque eleifend donec pretium vulputate s [Output was truncated. Please limit to 500 chars]"
     },
     {
-      "name": "ExampleHasStdoutOtherTest.test_dummy",
+      "name": "ExampleHasStdoutOther > dummy",
       "status": "fail",
-      "message": "One or more subtests for this test failed. Details can be found under each variant.",
+      "message": "One or more variations of this test failed. Details can be found under each [variant#].",
       "test_code": "input_data = ['frog', 'fish', 'coconut', 'pineapple', 'carrot', 'cucumber', 'grass', 'tree']\nresult_data = [(\"Hello, World!\", param) for param in input_data]\nnumber_of_variants = range(1, len(input_data) + 1)\n\nfor variant, param, result in zip(number_of_variants, input_data, result_data):\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result,\n                         msg=f'Expected: {result} but got something else instead.')",
       "task_id": 4
     },
     {
-      "name": "ExampleHasStdoutOtherTest.test_hello",
-      "status": "fail",
-      "message": "One or more subtests for this test failed. Details can be found under each variant.",
-      "test_code": "input_data = [1, 2, 5, 10, 15, 23, 33, 39]\nresult_data = [(\"Hello, World!\", param) for param in input_data]\nnumber_of_variants = range(1, len(input_data) + 1)\n\nfor variant, param, result in zip(number_of_variants, input_data, result_data):\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result,\n                         msg=f'Expected: {result} but got something else instead.')",
-      "task_id": 5
-    },
-    {
-      "name": "ExampleHasStdoutTest.test_hello [variation #1] (param=1, result=('Hello, World!', 1))",
-      "status": "fail",
-      "message": "AssertionError: None != ('Hello, World!', 1) : Expected: ('Hello, World!', 1) but got something else instead.",
-      "test_code": "input_data = [1, 2, 5, 10, 15, 23, 33, 39]\nresult_data = [(\"Hello, World!\", param) for param in input_data]\nnumber_of_variants = range(1, len(input_data) + 1)\n\nfor variant, param, result in zip(number_of_variants, input_data, result_data):\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result,\n                         msg=f'Expected: {result} but got something else instead.')",
-      "task_id": 1
-    },
-    {
-      "name": "ExampleHasStdoutTest.test_hello [variation #2] (param=2, result=('Hello, World!', 2))",
-      "status": "fail",
-      "message": "AssertionError: None != ('Hello, World!', 2) : Expected: ('Hello, World!', 2) but got something else instead.",
-      "test_code": "input_data = [1, 2, 5, 10, 15, 23, 33, 39]\nresult_data = [(\"Hello, World!\", param) for param in input_data]\nnumber_of_variants = range(1, len(input_data) + 1)\n\nfor variant, param, result in zip(number_of_variants, input_data, result_data):\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result,\n                         msg=f'Expected: {result} but got something else instead.')",
-      "task_id": 1
-    },
-    {
-      "name": "ExampleHasStdoutTest.test_hello [variation #3] (param=5, result=('Hello, World!', 5))",
-      "status": "fail",
-      "message": "AssertionError: None != ('Hello, World!', 5) : Expected: ('Hello, World!', 5) but got something else instead.",
-      "test_code": "input_data = [1, 2, 5, 10, 15, 23, 33, 39]\nresult_data = [(\"Hello, World!\", param) for param in input_data]\nnumber_of_variants = range(1, len(input_data) + 1)\n\nfor variant, param, result in zip(number_of_variants, input_data, result_data):\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result,\n                         msg=f'Expected: {result} but got something else instead.')",
-      "task_id": 1
-    },
-    {
-      "name": "ExampleHasStdoutTest.test_hello [variation #4] (param=10, result=('Hello, World!', 10))",
-      "status": "fail",
-      "message": "AssertionError: None != ('Hello, World!', 10) : Expected: ('Hello, World!', 10) but got something else instead.",
-      "test_code": "input_data = [1, 2, 5, 10, 15, 23, 33, 39]\nresult_data = [(\"Hello, World!\", param) for param in input_data]\nnumber_of_variants = range(1, len(input_data) + 1)\n\nfor variant, param, result in zip(number_of_variants, input_data, result_data):\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result,\n                         msg=f'Expected: {result} but got something else instead.')",
-      "task_id": 1
-    },
-    {
-      "name": "ExampleHasStdoutTest.test_hello [variation #5] (param=15, result=('Hello, World!', 15))",
-      "status": "fail",
-      "message": "AssertionError: None != ('Hello, World!', 15) : Expected: ('Hello, World!', 15) but got something else instead.",
-      "test_code": "input_data = [1, 2, 5, 10, 15, 23, 33, 39]\nresult_data = [(\"Hello, World!\", param) for param in input_data]\nnumber_of_variants = range(1, len(input_data) + 1)\n\nfor variant, param, result in zip(number_of_variants, input_data, result_data):\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result,\n                         msg=f'Expected: {result} but got something else instead.')",
-      "task_id": 1
-    },
-    {
-      "name": "ExampleHasStdoutTest.test_hello [variation #6] (param=23, result=('Hello, World!', 23))",
-      "status": "fail",
-      "message": "AssertionError: None != ('Hello, World!', 23) : Expected: ('Hello, World!', 23) but got something else instead.",
-      "test_code": "input_data = [1, 2, 5, 10, 15, 23, 33, 39]\nresult_data = [(\"Hello, World!\", param) for param in input_data]\nnumber_of_variants = range(1, len(input_data) + 1)\n\nfor variant, param, result in zip(number_of_variants, input_data, result_data):\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result,\n                         msg=f'Expected: {result} but got something else instead.')",
-      "task_id": 1
-    },
-    {
-      "name": "ExampleHasStdoutTest.test_hello [variation #7] (param=33, result=('Hello, World!', 33))",
-      "status": "fail",
-      "message": "AssertionError: None != ('Hello, World!', 33) : Expected: ('Hello, World!', 33) but got something else instead.",
-      "test_code": "input_data = [1, 2, 5, 10, 15, 23, 33, 39]\nresult_data = [(\"Hello, World!\", param) for param in input_data]\nnumber_of_variants = range(1, len(input_data) + 1)\n\nfor variant, param, result in zip(number_of_variants, input_data, result_data):\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result,\n                         msg=f'Expected: {result} but got something else instead.')",
-      "task_id": 1
-    },
-    {
-      "name": "ExampleHasStdoutTest.test_hello [variation #8] (param=39, result=('Hello, World!', 39))",
-      "status": "fail",
-      "message": "AssertionError: None != ('Hello, World!', 39) : Expected: ('Hello, World!', 39) but got something else instead.",
-      "test_code": "input_data = [1, 2, 5, 10, 15, 23, 33, 39]\nresult_data = [(\"Hello, World!\", param) for param in input_data]\nnumber_of_variants = range(1, len(input_data) + 1)\n\nfor variant, param, result in zip(number_of_variants, input_data, result_data):\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result,\n                         msg=f'Expected: {result} but got something else instead.')",
-      "task_id": 1
-    },
-    {
-      "name": "ExampleHasStdoutTest.test_abc [variation #1] (param='frog', result=('Hello, World!', 'frog'))",
-      "status": "fail",
-      "message": "AssertionError: None != ('Hello, World!', 'frog') : Expected: ('Hello, World!', 'frog') but got something else instead.",
-      "test_code": "input_data = ['frog', 'fish', 'coconut', 'pineapple', 'carrot', 'cucumber', 'grass', 'tree']\nresult_data = [(\"Hello, World!\", param) for param in input_data]\nnumber_of_variants = range(1, len(input_data) + 1)\n\nfor variant, param, result in zip(number_of_variants, input_data, result_data):\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result,\n                         msg=f'Expected: {result} but got something else instead.')",
-      "task_id": 2
-    },
-    {
-      "name": "ExampleHasStdoutTest.test_abc [variation #2] (param='fish', result=('Hello, World!', 'fish'))",
-      "status": "fail",
-      "message": "AssertionError: None != ('Hello, World!', 'fish') : Expected: ('Hello, World!', 'fish') but got something else instead.",
-      "test_code": "input_data = ['frog', 'fish', 'coconut', 'pineapple', 'carrot', 'cucumber', 'grass', 'tree']\nresult_data = [(\"Hello, World!\", param) for param in input_data]\nnumber_of_variants = range(1, len(input_data) + 1)\n\nfor variant, param, result in zip(number_of_variants, input_data, result_data):\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result,\n                         msg=f'Expected: {result} but got something else instead.')",
-      "task_id": 2
-    },
-    {
-      "name": "ExampleHasStdoutTest.test_abc [variation #3] (param='coconut', result=('Hello, World!', 'coconut'))",
-      "status": "fail",
-      "message": "AssertionError: None != ('Hello, World!', 'coconut') : Expected: ('Hello, World!', 'coconut') but got something else instead.",
-      "test_code": "input_data = ['frog', 'fish', 'coconut', 'pineapple', 'carrot', 'cucumber', 'grass', 'tree']\nresult_data = [(\"Hello, World!\", param) for param in input_data]\nnumber_of_variants = range(1, len(input_data) + 1)\n\nfor variant, param, result in zip(number_of_variants, input_data, result_data):\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result,\n                         msg=f'Expected: {result} but got something else instead.')",
-      "task_id": 2
-    },
-    {
-      "name": "ExampleHasStdoutTest.test_abc [variation #4] (param='pineapple', result=('Hello, World!', 'pineapple'))",
-      "status": "fail",
-      "message": "AssertionError: None != ('Hello, World!', 'pineapple') : Expected: ('Hello, World!', 'pineapple') but got something else instead.",
-      "test_code": "input_data = ['frog', 'fish', 'coconut', 'pineapple', 'carrot', 'cucumber', 'grass', 'tree']\nresult_data = [(\"Hello, World!\", param) for param in input_data]\nnumber_of_variants = range(1, len(input_data) + 1)\n\nfor variant, param, result in zip(number_of_variants, input_data, result_data):\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result,\n                         msg=f'Expected: {result} but got something else instead.')",
-      "task_id": 2
-    },
-    {
-      "name": "ExampleHasStdoutTest.test_abc [variation #5] (param='carrot', result=('Hello, World!', 'carrot'))",
-      "status": "fail",
-      "message": "AssertionError: None != ('Hello, World!', 'carrot') : Expected: ('Hello, World!', 'carrot') but got something else instead.",
-      "test_code": "input_data = ['frog', 'fish', 'coconut', 'pineapple', 'carrot', 'cucumber', 'grass', 'tree']\nresult_data = [(\"Hello, World!\", param) for param in input_data]\nnumber_of_variants = range(1, len(input_data) + 1)\n\nfor variant, param, result in zip(number_of_variants, input_data, result_data):\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result,\n                         msg=f'Expected: {result} but got something else instead.')",
-      "task_id": 2
-    },
-    {
-      "name": "ExampleHasStdoutTest.test_abc [variation #6] (param='cucumber', result=('Hello, World!', 'cucumber'))",
-      "status": "fail",
-      "message": "AssertionError: None != ('Hello, World!', 'cucumber') : Expected: ('Hello, World!', 'cucumber') but got something else instead.",
-      "test_code": "input_data = ['frog', 'fish', 'coconut', 'pineapple', 'carrot', 'cucumber', 'grass', 'tree']\nresult_data = [(\"Hello, World!\", param) for param in input_data]\nnumber_of_variants = range(1, len(input_data) + 1)\n\nfor variant, param, result in zip(number_of_variants, input_data, result_data):\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result,\n                         msg=f'Expected: {result} but got something else instead.')",
-      "task_id": 2
-    },
-    {
-      "name": "ExampleHasStdoutTest.test_abc [variation #7] (param='grass', result=('Hello, World!', 'grass'))",
-      "status": "fail",
-      "message": "AssertionError: None != ('Hello, World!', 'grass') : Expected: ('Hello, World!', 'grass') but got something else instead.",
-      "test_code": "input_data = ['frog', 'fish', 'coconut', 'pineapple', 'carrot', 'cucumber', 'grass', 'tree']\nresult_data = [(\"Hello, World!\", param) for param in input_data]\nnumber_of_variants = range(1, len(input_data) + 1)\n\nfor variant, param, result in zip(number_of_variants, input_data, result_data):\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result,\n                         msg=f'Expected: {result} but got something else instead.')",
-      "task_id": 2
-    },
-    {
-      "name": "ExampleHasStdoutTest.test_abc [variation #8] (param='tree', result=('Hello, World!', 'tree'))",
-      "status": "fail",
-      "message": "AssertionError: None != ('Hello, World!', 'tree') : Expected: ('Hello, World!', 'tree') but got something else instead.",
-      "test_code": "input_data = ['frog', 'fish', 'coconut', 'pineapple', 'carrot', 'cucumber', 'grass', 'tree']\nresult_data = [(\"Hello, World!\", param) for param in input_data]\nnumber_of_variants = range(1, len(input_data) + 1)\n\nfor variant, param, result in zip(number_of_variants, input_data, result_data):\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result,\n                         msg=f'Expected: {result} but got something else instead.')",
-      "task_id": 2
-    },
-    {
-      "name": "ExampleHasStdoutOtherTest.test_dummy [variation #1] (param='frog', result=('Hello, World!', 'frog'))",
+      "name": "ExampleHasStdoutOther > dummy [variation #1] (param='frog', result=('Hello, World!', 'frog'))",
       "status": "fail",
       "message": "AssertionError: None != ('Hello, World!', 'frog') : Expected: ('Hello, World!', 'frog') but got something else instead.",
       "test_code": "input_data = ['frog', 'fish', 'coconut', 'pineapple', 'carrot', 'cucumber', 'grass', 'tree']\nresult_data = [(\"Hello, World!\", param) for param in input_data]\nnumber_of_variants = range(1, len(input_data) + 1)\n\nfor variant, param, result in zip(number_of_variants, input_data, result_data):\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result,\n                         msg=f'Expected: {result} but got something else instead.')",
       "task_id": 4
     },
     {
-      "name": "ExampleHasStdoutOtherTest.test_dummy [variation #2] (param='fish', result=('Hello, World!', 'fish'))",
+      "name": "ExampleHasStdoutOther > dummy [variation #2] (param='fish', result=('Hello, World!', 'fish'))",
       "status": "fail",
       "message": "AssertionError: None != ('Hello, World!', 'fish') : Expected: ('Hello, World!', 'fish') but got something else instead.",
       "test_code": "input_data = ['frog', 'fish', 'coconut', 'pineapple', 'carrot', 'cucumber', 'grass', 'tree']\nresult_data = [(\"Hello, World!\", param) for param in input_data]\nnumber_of_variants = range(1, len(input_data) + 1)\n\nfor variant, param, result in zip(number_of_variants, input_data, result_data):\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result,\n                         msg=f'Expected: {result} but got something else instead.')",
       "task_id": 4
     },
     {
-      "name": "ExampleHasStdoutOtherTest.test_dummy [variation #3] (param='coconut', result=('Hello, World!', 'coconut'))",
+      "name": "ExampleHasStdoutOther > dummy [variation #3] (param='coconut', result=('Hello, World!', 'coconut'))",
       "status": "fail",
       "message": "AssertionError: None != ('Hello, World!', 'coconut') : Expected: ('Hello, World!', 'coconut') but got something else instead.",
       "test_code": "input_data = ['frog', 'fish', 'coconut', 'pineapple', 'carrot', 'cucumber', 'grass', 'tree']\nresult_data = [(\"Hello, World!\", param) for param in input_data]\nnumber_of_variants = range(1, len(input_data) + 1)\n\nfor variant, param, result in zip(number_of_variants, input_data, result_data):\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result,\n                         msg=f'Expected: {result} but got something else instead.')",
       "task_id": 4
     },
     {
-      "name": "ExampleHasStdoutOtherTest.test_dummy [variation #4] (param='pineapple', result=('Hello, World!', 'pineapple'))",
+      "name": "ExampleHasStdoutOther > dummy [variation #4] (param='pineapple', result=('Hello, World!', 'pineapple'))",
       "status": "fail",
       "message": "AssertionError: None != ('Hello, World!', 'pineapple') : Expected: ('Hello, World!', 'pineapple') but got something else instead.",
       "test_code": "input_data = ['frog', 'fish', 'coconut', 'pineapple', 'carrot', 'cucumber', 'grass', 'tree']\nresult_data = [(\"Hello, World!\", param) for param in input_data]\nnumber_of_variants = range(1, len(input_data) + 1)\n\nfor variant, param, result in zip(number_of_variants, input_data, result_data):\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result,\n                         msg=f'Expected: {result} but got something else instead.')",
       "task_id": 4
     },
     {
-      "name": "ExampleHasStdoutOtherTest.test_dummy [variation #5] (param='carrot', result=('Hello, World!', 'carrot'))",
+      "name": "ExampleHasStdoutOther > dummy [variation #5] (param='carrot', result=('Hello, World!', 'carrot'))",
       "status": "fail",
       "message": "AssertionError: None != ('Hello, World!', 'carrot') : Expected: ('Hello, World!', 'carrot') but got something else instead.",
       "test_code": "input_data = ['frog', 'fish', 'coconut', 'pineapple', 'carrot', 'cucumber', 'grass', 'tree']\nresult_data = [(\"Hello, World!\", param) for param in input_data]\nnumber_of_variants = range(1, len(input_data) + 1)\n\nfor variant, param, result in zip(number_of_variants, input_data, result_data):\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result,\n                         msg=f'Expected: {result} but got something else instead.')",
       "task_id": 4
     },
     {
-      "name": "ExampleHasStdoutOtherTest.test_dummy [variation #6] (param='cucumber', result=('Hello, World!', 'cucumber'))",
+      "name": "ExampleHasStdoutOther > dummy [variation #6] (param='cucumber', result=('Hello, World!', 'cucumber'))",
       "status": "fail",
       "message": "AssertionError: None != ('Hello, World!', 'cucumber') : Expected: ('Hello, World!', 'cucumber') but got something else instead.",
       "test_code": "input_data = ['frog', 'fish', 'coconut', 'pineapple', 'carrot', 'cucumber', 'grass', 'tree']\nresult_data = [(\"Hello, World!\", param) for param in input_data]\nnumber_of_variants = range(1, len(input_data) + 1)\n\nfor variant, param, result in zip(number_of_variants, input_data, result_data):\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result,\n                         msg=f'Expected: {result} but got something else instead.')",
       "task_id": 4
     },
     {
-      "name": "ExampleHasStdoutOtherTest.test_dummy [variation #7] (param='grass', result=('Hello, World!', 'grass'))",
+      "name": "ExampleHasStdoutOther > dummy [variation #7] (param='grass', result=('Hello, World!', 'grass'))",
       "status": "fail",
       "message": "AssertionError: None != ('Hello, World!', 'grass') : Expected: ('Hello, World!', 'grass') but got something else instead.",
       "test_code": "input_data = ['frog', 'fish', 'coconut', 'pineapple', 'carrot', 'cucumber', 'grass', 'tree']\nresult_data = [(\"Hello, World!\", param) for param in input_data]\nnumber_of_variants = range(1, len(input_data) + 1)\n\nfor variant, param, result in zip(number_of_variants, input_data, result_data):\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result,\n                         msg=f'Expected: {result} but got something else instead.')",
       "task_id": 4
     },
     {
-      "name": "ExampleHasStdoutOtherTest.test_dummy [variation #8] (param='tree', result=('Hello, World!', 'tree'))",
+      "name": "ExampleHasStdoutOther > dummy [variation #8] (param='tree', result=('Hello, World!', 'tree'))",
       "status": "fail",
       "message": "AssertionError: None != ('Hello, World!', 'tree') : Expected: ('Hello, World!', 'tree') but got something else instead.",
       "test_code": "input_data = ['frog', 'fish', 'coconut', 'pineapple', 'carrot', 'cucumber', 'grass', 'tree']\nresult_data = [(\"Hello, World!\", param) for param in input_data]\nnumber_of_variants = range(1, len(input_data) + 1)\n\nfor variant, param, result in zip(number_of_variants, input_data, result_data):\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result,\n                         msg=f'Expected: {result} but got something else instead.')",
       "task_id": 4
     },
     {
-      "name": "ExampleHasStdoutOtherTest.test_hello [variation #1] (param=1, result=('Hello, World!', 1))",
+      "name": "ExampleHasStdoutOther > hello",
+      "status": "fail",
+      "message": "One or more variations of this test failed. Details can be found under each [variant#].",
+      "test_code": "input_data = [1, 2, 5, 10, 15, 23, 33, 39]\nresult_data = [(\"Hello, World!\", param) for param in input_data]\nnumber_of_variants = range(1, len(input_data) + 1)\n\nfor variant, param, result in zip(number_of_variants, input_data, result_data):\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result,\n                         msg=f'Expected: {result} but got something else instead.')",
+      "task_id": 5
+    },
+    {
+      "name": "ExampleHasStdoutOther > hello [variation #1] (param=1, result=('Hello, World!', 1))",
       "status": "fail",
       "message": "AssertionError: None != ('Hello, World!', 1) : Expected: ('Hello, World!', 1) but got something else instead.",
       "test_code": "input_data = [1, 2, 5, 10, 15, 23, 33, 39]\nresult_data = [(\"Hello, World!\", param) for param in input_data]\nnumber_of_variants = range(1, len(input_data) + 1)\n\nfor variant, param, result in zip(number_of_variants, input_data, result_data):\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result,\n                         msg=f'Expected: {result} but got something else instead.')",
       "task_id": 5
     },
     {
-      "name": "ExampleHasStdoutOtherTest.test_hello [variation #2] (param=2, result=('Hello, World!', 2))",
+      "name": "ExampleHasStdoutOther > hello [variation #2] (param=2, result=('Hello, World!', 2))",
       "status": "fail",
       "message": "AssertionError: None != ('Hello, World!', 2) : Expected: ('Hello, World!', 2) but got something else instead.",
       "test_code": "input_data = [1, 2, 5, 10, 15, 23, 33, 39]\nresult_data = [(\"Hello, World!\", param) for param in input_data]\nnumber_of_variants = range(1, len(input_data) + 1)\n\nfor variant, param, result in zip(number_of_variants, input_data, result_data):\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result,\n                         msg=f'Expected: {result} but got something else instead.')",
       "task_id": 5
     },
     {
-      "name": "ExampleHasStdoutOtherTest.test_hello [variation #3] (param=5, result=('Hello, World!', 5))",
+      "name": "ExampleHasStdoutOther > hello [variation #3] (param=5, result=('Hello, World!', 5))",
       "status": "fail",
       "message": "AssertionError: None != ('Hello, World!', 5) : Expected: ('Hello, World!', 5) but got something else instead.",
       "test_code": "input_data = [1, 2, 5, 10, 15, 23, 33, 39]\nresult_data = [(\"Hello, World!\", param) for param in input_data]\nnumber_of_variants = range(1, len(input_data) + 1)\n\nfor variant, param, result in zip(number_of_variants, input_data, result_data):\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result,\n                         msg=f'Expected: {result} but got something else instead.')",
       "task_id": 5
     },
     {
-      "name": "ExampleHasStdoutOtherTest.test_hello [variation #4] (param=10, result=('Hello, World!', 10))",
+      "name": "ExampleHasStdoutOther > hello [variation #4] (param=10, result=('Hello, World!', 10))",
       "status": "fail",
       "message": "AssertionError: None != ('Hello, World!', 10) : Expected: ('Hello, World!', 10) but got something else instead.",
       "test_code": "input_data = [1, 2, 5, 10, 15, 23, 33, 39]\nresult_data = [(\"Hello, World!\", param) for param in input_data]\nnumber_of_variants = range(1, len(input_data) + 1)\n\nfor variant, param, result in zip(number_of_variants, input_data, result_data):\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result,\n                         msg=f'Expected: {result} but got something else instead.')",
       "task_id": 5
     },
     {
-      "name": "ExampleHasStdoutOtherTest.test_hello [variation #5] (param=15, result=('Hello, World!', 15))",
+      "name": "ExampleHasStdoutOther > hello [variation #5] (param=15, result=('Hello, World!', 15))",
       "status": "fail",
       "message": "AssertionError: None != ('Hello, World!', 15) : Expected: ('Hello, World!', 15) but got something else instead.",
       "test_code": "input_data = [1, 2, 5, 10, 15, 23, 33, 39]\nresult_data = [(\"Hello, World!\", param) for param in input_data]\nnumber_of_variants = range(1, len(input_data) + 1)\n\nfor variant, param, result in zip(number_of_variants, input_data, result_data):\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result,\n                         msg=f'Expected: {result} but got something else instead.')",
       "task_id": 5
     },
     {
-      "name": "ExampleHasStdoutOtherTest.test_hello [variation #6] (param=23, result=('Hello, World!', 23))",
+      "name": "ExampleHasStdoutOther > hello [variation #6] (param=23, result=('Hello, World!', 23))",
       "status": "fail",
       "message": "AssertionError: None != ('Hello, World!', 23) : Expected: ('Hello, World!', 23) but got something else instead.",
       "test_code": "input_data = [1, 2, 5, 10, 15, 23, 33, 39]\nresult_data = [(\"Hello, World!\", param) for param in input_data]\nnumber_of_variants = range(1, len(input_data) + 1)\n\nfor variant, param, result in zip(number_of_variants, input_data, result_data):\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result,\n                         msg=f'Expected: {result} but got something else instead.')",
       "task_id": 5
     },
     {
-      "name": "ExampleHasStdoutOtherTest.test_hello [variation #7] (param=33, result=('Hello, World!', 33))",
+      "name": "ExampleHasStdoutOther > hello [variation #7] (param=33, result=('Hello, World!', 33))",
       "status": "fail",
       "message": "AssertionError: None != ('Hello, World!', 33) : Expected: ('Hello, World!', 33) but got something else instead.",
       "test_code": "input_data = [1, 2, 5, 10, 15, 23, 33, 39]\nresult_data = [(\"Hello, World!\", param) for param in input_data]\nnumber_of_variants = range(1, len(input_data) + 1)\n\nfor variant, param, result in zip(number_of_variants, input_data, result_data):\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result,\n                         msg=f'Expected: {result} but got something else instead.')",
       "task_id": 5
     },
     {
-      "name": "ExampleHasStdoutOtherTest.test_hello [variation #8] (param=39, result=('Hello, World!', 39))",
+      "name": "ExampleHasStdoutOther > hello [variation #8] (param=39, result=('Hello, World!', 39))",
       "status": "fail",
       "message": "AssertionError: None != ('Hello, World!', 39) : Expected: ('Hello, World!', 39) but got something else instead.",
       "test_code": "input_data = [1, 2, 5, 10, 15, 23, 33, 39]\nresult_data = [(\"Hello, World!\", param) for param in input_data]\nnumber_of_variants = range(1, len(input_data) + 1)\n\nfor variant, param, result in zip(number_of_variants, input_data, result_data):\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result,\n                         msg=f'Expected: {result} but got something else instead.')",

--- a/test/example-has-stdout/results.json
+++ b/test/example-has-stdout/results.json
@@ -3,7 +3,7 @@
   "status": "fail",
   "tests": [
     {
-      "name": "ExampleHasStdoutTest.test_hello",
+      "name": "ExampleHasStdout > hello",
       "status": "fail",
       "message": "AssertionError: None != 'Hello, World!'",
       "test_code": "self.assertEqual(hello(), \"Hello, World!\")",
@@ -11,7 +11,7 @@
       "output": "Hello, World!"
     },
     {
-      "name": "ExampleHasStdoutTest.test_abc",
+      "name": "ExampleHasStdout > abc",
       "status": "fail",
       "message": "AssertionError: None != 'Hello, World!'",
       "test_code": "self.assertEqual(hello(), \"Hello, World!\")",
@@ -19,7 +19,7 @@
       "output": "Hello, World!"
     },
     {
-      "name": "ExampleHasStdoutTest.test_trancation",
+      "name": "ExampleHasStdout > trancation",
       "status": "fail",
       "message": "AssertionError: 'Goodbye!' != 'Hello, World!'\n- Goodbye!\n+ Hello, World!",
       "test_code": "self.assertEqual(must_truncate(), \"Hello, World!\")",
@@ -27,7 +27,7 @@
       "output": "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Vulputate ut pharetra sit amet aliquam. Amet dictum sit amet justo donec enim diam vulputate ut. Consequat nisl vel pretium lectus quam id leo. Maecenas accumsan lacus vel facilisis volutpat est velit egestas dui. Faucibus et molestie ac feugiat sed. Fringilla phasellus faucibus scelerisque eleifend donec pretium vulputate s [Output was truncated. Please limit to 500 chars]"
     },
     {
-      "name": "ExampleHasStdoutOtherTest.test_dummy",
+      "name": "ExampleHasStdoutOther > dummy",
       "status": "fail",
       "message": "AssertionError: None != 'Hello, World!'",
       "test_code": "self.assertEqual(hello(), \"Hello, World!\")",
@@ -35,7 +35,7 @@
       "output": "Hello, World!"
     },
     {
-      "name": "ExampleHasStdoutOtherTest.test_hello",
+      "name": "ExampleHasStdoutOther > hello",
       "status": "fail",
       "message": "AssertionError: None != 'Hello, World!'",
       "test_code": "self.assertEqual(hello(), \"Hello, World!\")",

--- a/test/example-partial-fail/results.json
+++ b/test/example-partial-fail/results.json
@@ -3,27 +3,27 @@
   "status": "fail",
   "tests": [
     {
-      "name": "ExamplePartialFailTest.test_hello",
+      "name": "ExamplePartialFail > hello",
       "status": "fail",
       "message": "AssertionError: 'Hello, World!' != 'Goodbye'\n- Hello, World!\n+ Goodbye",
       "test_code": "self.assertEqual(hello(), \"Goodbye\")",
       "task_id": 0
     },
     {
-      "name": "ExamplePartialFailTest.test_abc",
+      "name": "ExamplePartialFail > abc",
       "status": "pass",
       "test_code": "self.assertEqual(hello(), \"Hello, World!\")",
       "task_id": 0
     },
     {
-      "name": "ExamplePartialFailOtherTest.test_dummy",
+      "name": "ExamplePartialFailOther > dummy",
       "status": "fail",
       "message": "AssertionError: 'Hello, World!' != 'Goodbye'\n- Hello, World!\n+ Goodbye",
       "test_code": "self.assertEqual(hello(), \"Goodbye\")",
       "task_id": 0
     },
     {
-      "name": "ExamplePartialFailOtherTest.test_hello",
+      "name": "ExamplePartialFailOther > hello",
       "status": "pass",
       "test_code": "self.assertEqual(hello(), \"Hello, World!\")",
       "task_id": 0

--- a/test/example-partial-failure-with-subtests/results.json
+++ b/test/example-partial-failure-with-subtests/results.json
@@ -3,82 +3,82 @@
   "status": "fail",
   "tests": [
     {
-      "name": "ExamplePartialFailureWithSubtestsTest.test_abc",
+      "name": "ExamplePartialFailureWithSubtests > abc",
       "status": "pass",
       "test_code": "input_data = ['frog', 'fish', 'coconut', 'pineapple', 'carrot', 'cucumber', 'grass', 'tree']\nresult_data = [(\"Hello, World!\", param) for param in input_data]\nnumber_of_variants = range(1, len(input_data) + 1)\n\nfor variant, param, result in zip(number_of_variants, input_data, result_data):\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result,\n                         msg=f'Expected: {result} but got something else instead.')",
       "task_id": 1
     },
     {
-      "name": "ExamplePartialFailureWithSubtestsTest.test_hello",
+      "name": "ExamplePartialFailureWithSubtests > hello",
       "status": "fail",
-      "message": "One or more subtests for this test failed. Details can be found under each variant.",
+      "message": "One or more variations of this test failed. Details can be found under each [variant#].",
       "test_code": "input_data = [1, 2, 5, 10]\nresult_data = [(\"Hello, World!\", param) for param in input_data]\nnumber_of_variants = range(1, len(input_data) + 1)\n\nfor variant, param, result in zip(number_of_variants, input_data, result_data):\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result,\n                         msg=f'Expected: {result} but got something else instead.')",
       "task_id": 1
     },
     {
-      "name": "ExamplePartialFailureWithSubtestsOtherTest.test_dummy",
-      "status": "pass",
-      "test_code": "input_data = ['frog', 'fish', 'coconut', 'pineapple', 'carrot', 'cucumber', 'grass', 'tree']\nresult_data = [(\"Hello, World!\", param) for param in input_data]\nnumber_of_variants = range(1, len(input_data) + 1)\n\nfor variant, param, result in zip(number_of_variants, input_data, result_data):\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result,\n                         msg=f'Expected: {result} but got something else instead.')",
-      "task_id": 2
-    },
-    {
-      "name": "ExamplePartialFailureWithSubtestsOtherTest.test_hello",
-      "status": "fail",
-      "message": "One or more subtests for this test failed. Details can be found under each variant.",
-      "test_code": "input_data = [15, 23, 33, 39]\nresult_data = [(\"Hello, World!\", param) for param in input_data]\nnumber_of_variants = range(1, len(input_data) + 1)\n\nfor variant, param, result in zip(number_of_variants, input_data, result_data):\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result,\n                         msg=f'Expected: {result} but got something else instead.')",
-      "task_id": 2
-    },
-    {
-      "name": "ExamplePartialFailureWithSubtestsTest.test_hello [variation #1] (param=1, result=('Hello, World!', 1))",
+      "name": "ExamplePartialFailureWithSubtests > hello [variation #1] (param=1, result=('Hello, World!', 1))",
       "status": "fail",
       "message": "AssertionError: 'Hello, World!' != ('Hello, World!', 1) : Expected: ('Hello, World!', 1) but got something else instead.",
       "test_code": "input_data = [1, 2, 5, 10]\nresult_data = [(\"Hello, World!\", param) for param in input_data]\nnumber_of_variants = range(1, len(input_data) + 1)\n\nfor variant, param, result in zip(number_of_variants, input_data, result_data):\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result,\n                         msg=f'Expected: {result} but got something else instead.')",
       "task_id": 1
     },
     {
-      "name": "ExamplePartialFailureWithSubtestsTest.test_hello [variation #2] (param=2, result=('Hello, World!', 2))",
+      "name": "ExamplePartialFailureWithSubtests > hello [variation #2] (param=2, result=('Hello, World!', 2))",
       "status": "fail",
       "message": "AssertionError: 'Hello, World!' != ('Hello, World!', 2) : Expected: ('Hello, World!', 2) but got something else instead.",
       "test_code": "input_data = [1, 2, 5, 10]\nresult_data = [(\"Hello, World!\", param) for param in input_data]\nnumber_of_variants = range(1, len(input_data) + 1)\n\nfor variant, param, result in zip(number_of_variants, input_data, result_data):\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result,\n                         msg=f'Expected: {result} but got something else instead.')",
       "task_id": 1
     },
     {
-      "name": "ExamplePartialFailureWithSubtestsTest.test_hello [variation #3] (param=5, result=('Hello, World!', 5))",
+      "name": "ExamplePartialFailureWithSubtests > hello [variation #3] (param=5, result=('Hello, World!', 5))",
       "status": "fail",
       "message": "AssertionError: 'Hello, World!' != ('Hello, World!', 5) : Expected: ('Hello, World!', 5) but got something else instead.",
       "test_code": "input_data = [1, 2, 5, 10]\nresult_data = [(\"Hello, World!\", param) for param in input_data]\nnumber_of_variants = range(1, len(input_data) + 1)\n\nfor variant, param, result in zip(number_of_variants, input_data, result_data):\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result,\n                         msg=f'Expected: {result} but got something else instead.')",
       "task_id": 1
     },
     {
-      "name": "ExamplePartialFailureWithSubtestsTest.test_hello [variation #4] (param=10, result=('Hello, World!', 10))",
+      "name": "ExamplePartialFailureWithSubtests > hello [variation #4] (param=10, result=('Hello, World!', 10))",
       "status": "fail",
       "message": "AssertionError: 'Hello, World!' != ('Hello, World!', 10) : Expected: ('Hello, World!', 10) but got something else instead.",
       "test_code": "input_data = [1, 2, 5, 10]\nresult_data = [(\"Hello, World!\", param) for param in input_data]\nnumber_of_variants = range(1, len(input_data) + 1)\n\nfor variant, param, result in zip(number_of_variants, input_data, result_data):\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result,\n                         msg=f'Expected: {result} but got something else instead.')",
       "task_id": 1
     },
     {
-      "name": "ExamplePartialFailureWithSubtestsOtherTest.test_hello [variation #1] (param=15, result=('Hello, World!', 15))",
+      "name": "ExamplePartialFailureWithSubtestsOther > dummy",
+      "status": "pass",
+      "test_code": "input_data = ['frog', 'fish', 'coconut', 'pineapple', 'carrot', 'cucumber', 'grass', 'tree']\nresult_data = [(\"Hello, World!\", param) for param in input_data]\nnumber_of_variants = range(1, len(input_data) + 1)\n\nfor variant, param, result in zip(number_of_variants, input_data, result_data):\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result,\n                         msg=f'Expected: {result} but got something else instead.')",
+      "task_id": 2
+    },
+    {
+      "name": "ExamplePartialFailureWithSubtestsOther > hello",
+      "status": "fail",
+      "message": "One or more variations of this test failed. Details can be found under each [variant#].",
+      "test_code": "input_data = [15, 23, 33, 39]\nresult_data = [(\"Hello, World!\", param) for param in input_data]\nnumber_of_variants = range(1, len(input_data) + 1)\n\nfor variant, param, result in zip(number_of_variants, input_data, result_data):\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result,\n                         msg=f'Expected: {result} but got something else instead.')",
+      "task_id": 2
+    },
+    {
+      "name": "ExamplePartialFailureWithSubtestsOther > hello [variation #1] (param=15, result=('Hello, World!', 15))",
       "status": "fail",
       "message": "AssertionError: 'Hello, World!' != ('Hello, World!', 15) : Expected: ('Hello, World!', 15) but got something else instead.",
       "test_code": "input_data = [15, 23, 33, 39]\nresult_data = [(\"Hello, World!\", param) for param in input_data]\nnumber_of_variants = range(1, len(input_data) + 1)\n\nfor variant, param, result in zip(number_of_variants, input_data, result_data):\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result,\n                         msg=f'Expected: {result} but got something else instead.')",
       "task_id": 2
     },
     {
-      "name": "ExamplePartialFailureWithSubtestsOtherTest.test_hello [variation #2] (param=23, result=('Hello, World!', 23))",
+      "name": "ExamplePartialFailureWithSubtestsOther > hello [variation #2] (param=23, result=('Hello, World!', 23))",
       "status": "fail",
       "message": "AssertionError: 'Hello, World!' != ('Hello, World!', 23) : Expected: ('Hello, World!', 23) but got something else instead.",
       "test_code": "input_data = [15, 23, 33, 39]\nresult_data = [(\"Hello, World!\", param) for param in input_data]\nnumber_of_variants = range(1, len(input_data) + 1)\n\nfor variant, param, result in zip(number_of_variants, input_data, result_data):\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result,\n                         msg=f'Expected: {result} but got something else instead.')",
       "task_id": 2
     },
     {
-      "name": "ExamplePartialFailureWithSubtestsOtherTest.test_hello [variation #3] (param=33, result=('Hello, World!', 33))",
+      "name": "ExamplePartialFailureWithSubtestsOther > hello [variation #3] (param=33, result=('Hello, World!', 33))",
       "status": "fail",
       "message": "AssertionError: 'Hello, World!' != ('Hello, World!', 33) : Expected: ('Hello, World!', 33) but got something else instead.",
       "test_code": "input_data = [15, 23, 33, 39]\nresult_data = [(\"Hello, World!\", param) for param in input_data]\nnumber_of_variants = range(1, len(input_data) + 1)\n\nfor variant, param, result in zip(number_of_variants, input_data, result_data):\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result,\n                         msg=f'Expected: {result} but got something else instead.')",
       "task_id": 2
     },
     {
-      "name": "ExamplePartialFailureWithSubtestsOtherTest.test_hello [variation #4] (param=39, result=('Hello, World!', 39))",
+      "name": "ExamplePartialFailureWithSubtestsOther > hello [variation #4] (param=39, result=('Hello, World!', 39))",
       "status": "fail",
       "message": "AssertionError: 'Hello, World!' != ('Hello, World!', 39) : Expected: ('Hello, World!', 39) but got something else instead.",
       "test_code": "input_data = [15, 23, 33, 39]\nresult_data = [(\"Hello, World!\", param) for param in input_data]\nnumber_of_variants = range(1, len(input_data) + 1)\n\nfor variant, param, result in zip(number_of_variants, input_data, result_data):\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result,\n                         msg=f'Expected: {result} but got something else instead.')",

--- a/test/example-success-with-subtests/results.json
+++ b/test/example-success-with-subtests/results.json
@@ -3,28 +3,28 @@
   "status": "pass",
   "tests": [
     {
-      "name": "ExampleSuccessWithSubtestsTest.test_abc",
+      "name": "ExampleSuccessWithSubtests > abc",
       "status": "pass",
       "test_code": "input_data = ['frog', 'fish', 'coconut', 'pineapple', 'carrot', 'cucumber', 'grass', 'tree']\nresult_data = [(\"Hello, World!\", param) for param in input_data]\nnumber_of_variants = range(1, len(input_data) + 1)\n\nfor variant, param, result in zip(number_of_variants, input_data, result_data):\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result,\n                         msg=f'Expected: {result} but got something else instead.')",
       "task_id": 1,
       "output": "User output is captured!\nUser output is captured!\nUser output is captured!\nUser output is captured!\nUser output is captured!\nUser output is captured!\nUser output is captured!\nUser output is captured!"
     },
     {
-      "name": "ExampleSuccessWithSubtestsTest.test_hello",
+      "name": "ExampleSuccessWithSubtests > hello",
       "status": "pass",
       "test_code": "input_data = [1, 2, 5, 10, 15, 23, 33, 39]\nresult_data = [(\"Hello, World!\", param) for param in input_data]\nnumber_of_variants = range(1, len(input_data) + 1)\n\nfor variant, param, result in zip(number_of_variants, input_data, result_data):\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result,\n                         msg=f'Expected: {result} but got something else instead.')",
       "task_id": 1,
       "output": "User output is captured!\nUser output is captured!\nUser output is captured!\nUser output is captured!\nUser output is captured!\nUser output is captured!\nUser output is captured!\nUser output is captured!"
     },
     {
-      "name": "ExampleSuccessWithSubtestsOtherTest.test_dummy",
+      "name": "ExampleSuccessWithSubtestsOther > dummy",
       "status": "pass",
       "test_code": "input_data = ['frog', 'fish', 'coconut', 'pineapple', 'carrot', 'cucumber', 'grass', 'tree']\nresult_data = [(\"Hello, World!\", param) for param in input_data]\nnumber_of_variants = range(1, len(input_data) + 1)\n\nfor variant, param, result in zip(number_of_variants, input_data, result_data):\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result,\n                         msg=f'Expected: {result} but got something else instead.')",
       "task_id": 2,
       "output": "User output is captured!\nUser output is captured!\nUser output is captured!\nUser output is captured!\nUser output is captured!\nUser output is captured!\nUser output is captured!\nUser output is captured!"
     },
     {
-      "name": "ExampleSuccessWithSubtestsOtherTest.test_hello",
+      "name": "ExampleSuccessWithSubtestsOther > hello",
       "status": "pass",
       "test_code": "input_data = [1, 2, 5, 10, 15, 23, 33, 39]\nresult_data = [(\"Hello, World!\", param) for param in input_data]\nnumber_of_variants = range(1, len(input_data) + 1)\n\nfor variant, param, result in zip(number_of_variants, input_data, result_data):\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result,\n                         msg=f'Expected: {result} but got something else instead.')",
       "task_id": 2,

--- a/test/example-success/results.json
+++ b/test/example-success/results.json
@@ -3,28 +3,28 @@
   "status": "pass",
   "tests": [
     {
-      "name": "ExampleSuccessTest.test_hello",
+      "name": "ExampleSuccess > hello",
       "status": "pass",
       "test_code": "self.assertEqual(hello(), \"Hello, World!\")",
       "task_id": 0,
       "output": "User output is captured!"
     },
     {
-      "name": "ExampleSuccessTest.test_abc",
+      "name": "ExampleSuccess > abc",
       "status": "pass",
       "test_code": "self.assertEqual(hello(), \"Hello, World!\")",
       "task_id": 0,
       "output": "User output is captured!"
     },
     {
-      "name": "ExampleSuccessOtherTest.test_dummy",
+      "name": "ExampleSuccessOther > dummy",
       "status": "pass",
       "test_code": "self.assertEqual(hello(), \"Hello, World!\")",
       "task_id": 0,
       "output": "User output is captured!"
     },
     {
-      "name": "ExampleSuccessOtherTest.test_hello",
+      "name": "ExampleSuccessOther > hello",
       "status": "pass",
       "test_code": "self.assertEqual(hello(), \"Hello, World!\")",
       "task_id": 0,

--- a/test/example-syntax-erro/results.json
+++ b/test/example-syntax-erro/results.json
@@ -1,0 +1,6 @@
+{
+  "version": 3,
+  "status": "error",
+  "message": "Unexpected ExitCode.USAGE_ERROR: check logs for details",
+  "tests": []
+}

--- a/test/example-with-config-multiple-files/results.json
+++ b/test/example-with-config-multiple-files/results.json
@@ -3,56 +3,56 @@
   "status": "pass",
   "tests": [
     {
-      "name": "ExampleFirstTest.test_hello",
+      "name": "ExampleFirst > hello",
       "status": "pass",
       "test_code": "self.assertEqual(hello(), \"Hello, World!\")",
       "task_id": 0,
       "output": "User output is captured!"
     },
     {
-      "name": "ExampleSecondTest.test_hello",
+      "name": "ExampleSecond > hello",
       "status": "pass",
       "test_code": "self.assertEqual(hello(), \"Hello, World!\")",
       "task_id": 0,
       "output": "User output is captured!"
     },
     {
-      "name": "ExampleFirstTest.test_abc",
+      "name": "ExampleFirst > abc",
       "status": "pass",
       "test_code": "self.assertEqual(hello(), \"Hello, World!\")",
       "task_id": 0,
       "output": "User output is captured!"
     },
     {
-      "name": "ExampleSecondTest.test_abc",
+      "name": "ExampleSecond > abc",
       "status": "pass",
       "test_code": "self.assertEqual(hello(), \"Hello, World!\")",
       "task_id": 0,
       "output": "User output is captured!"
     },
     {
-      "name": "ExampleFirstOtherTest.test_dummy",
+      "name": "ExampleFirstOther > dummy",
       "status": "pass",
       "test_code": "self.assertEqual(hello(), \"Hello, World!\")",
       "task_id": 0,
       "output": "User output is captured!"
     },
     {
-      "name": "ExampleSecondOtherTest.test_dummy",
+      "name": "ExampleSecondOther > dummy",
       "status": "pass",
       "test_code": "self.assertEqual(hello(), \"Hello, World!\")",
       "task_id": 0,
       "output": "User output is captured!"
     },
     {
-      "name": "ExampleFirstOtherTest.test_hello",
+      "name": "ExampleFirstOther > hello",
       "status": "pass",
       "test_code": "self.assertEqual(hello(), \"Hello, World!\")",
       "task_id": 0,
       "output": "User output is captured!"
     },
     {
-      "name": "ExampleSecondOtherTest.test_hello",
+      "name": "ExampleSecondOther > hello",
       "status": "pass",
       "test_code": "self.assertEqual(hello(), \"Hello, World!\")",
       "task_id": 0,

--- a/test/example-with-config/results.json
+++ b/test/example-with-config/results.json
@@ -3,28 +3,28 @@
   "status": "pass",
   "tests": [
     {
-      "name": "ExampleWithConfigTest.test_hello",
+      "name": "ExampleWithConfig > hello",
       "status": "pass",
       "test_code": "self.assertEqual(hello(), \"Hello, World!\")",
       "task_id": 0,
       "output": "User output is captured!"
     },
     {
-      "name": "ExampleWithConfigTest.test_abc",
+      "name": "ExampleWithConfig > abc",
       "status": "pass",
       "test_code": "self.assertEqual(hello(), \"Hello, World!\")",
       "task_id": 0,
       "output": "User output is captured!"
     },
     {
-      "name": "ExampleWithConfigOtherTest.test_dummy",
+      "name": "ExampleWithConfigOther > dummy",
       "status": "pass",
       "test_code": "self.assertEqual(hello(), \"Hello, World!\")",
       "task_id": 0,
       "output": "User output is captured!"
     },
     {
-      "name": "ExampleWithConfigOtherTest.test_hello",
+      "name": "ExampleWithConfigOther > hello",
       "status": "pass",
       "test_code": "self.assertEqual(hello(), \"Hello, World!\")",
       "task_id": 0,


### PR DESCRIPTION
- [x] Modified the JSON output to sort tests by `taskno`
- [x] Modified the JSON output to strip the `Test.test_` verbiage from test names, and re-format test names to
         `<concept or exercise name>` **>** `<test name without underscores>` (_see two examples below_)
          <p align="left"><img src="https://user-images.githubusercontent.com/5923094/131373177-a1aea490-aab6-41ac-8fbb-541b7f445278.png" width="450"></p>

<p align="left"><img src="https://user-images.githubusercontent.com/5923094/131375714-61f7c2a3-5a48-45a4-8033-fdb3c8cfd147.png" width="550"></p>

 
- [x] Changed variation message that shows when variants (subtests) are output.