### PR TITLE
[Runner] Changed top-level Error Cap

### DIFF
--- a/runner/__init__.py
+++ b/runner/__init__.py
@@ -59,7 +59,7 @@ class ResultsReporter:
 
         state = self.tests[name]
 
-        # ignore succesful setup and teardown stages
+        # ignore successful setup and teardown stages
         if report.passed and report.when != "call":
             return
 
@@ -73,7 +73,7 @@ class ResultsReporter:
 
         # handle test failure
         if report.failed:
-
+            state.output = report.capstdout
             # traceback that caused the issued, if any
             message = None
             if report.longrepr:
@@ -91,7 +91,7 @@ class ResultsReporter:
         source = Path(self.config.rootdir) / report.fspath
         state.test_code = TestOrder.function_source(test_id, source)
 
-        # Looks up tast_ids from parent when the test is a subtest.
+        # Looks up test_ids from parent when the test is a subtest.
         if state.task_id == 0 and 'variation' in state.name:
             parent_test_name = state.name.split(' ')[0]
             parent_task_id = self.tests[parent_test_name].task_id
@@ -139,7 +139,7 @@ class ResultsReporter:
         if report.outcome == "failed":
             excinfo = call.excinfo
             err = excinfo.getrepr(style="no", abspath=False)
-            trace = err.chain[0][0]
+            trace = err.chain[-1][0]
             crash = err.chain[0][1]
             self.last_err = self._make_message(trace, crash)
 
@@ -147,8 +147,9 @@ class ResultsReporter:
         """
         Make a formatted message for reporting.
         """
+
         # stringify the traceback, strip pytest-specific formatting
-        message = dedent(re.sub("^E ", "  ", str(trace), flags=re.M))
+        message = dedent(re.sub("^E | _pytest.nodes.Collector.CollectError: ", "  ", str(trace), flags=re.M))
 
         # if a path exists that's relative to the runner we can strip it out
         if crash:

--- a/runner/__init__.py
+++ b/runner/__init__.py
@@ -73,7 +73,7 @@ class ResultsReporter:
 
         # handle test failure
         if report.failed:
-            #state.output = report.capstdout
+
             # traceback that caused the issued, if any
             message = None
             if report.longrepr:

--- a/runner/__init__.py
+++ b/runner/__init__.py
@@ -73,7 +73,7 @@ class ResultsReporter:
 
         # handle test failure
         if report.failed:
-            state.output = report.capstdout
+            #state.output = report.capstdout
             # traceback that caused the issued, if any
             message = None
             if report.longrepr:

--- a/test/example-empty-file/results.json
+++ b/test/example-empty-file/results.json
@@ -1,6 +1,6 @@
 {
   "version": 3,
   "status": "error",
-  "message": "ImportError: cannot import name 'hello' from 'example_empty_file' (./test/example-empty-file/example_empty_file.py)",
+  "message": " ImportError while importing test module '.solution.example_empty_file_test.py'.\nHint: make sure your test modules.packages have valid Python names.\nTraceback:\n.usr.local.lib.python3.9.importlib.__init__.py:127: in import_module\n    return _bootstrap._gcd_import(name[level:], package, level)\n.solution.example_empty_file_test.py:4: in <module>\n    from example_empty_file import hello\nE   ImportError: cannot import name 'hello' from 'example_empty_file' (.solution.example_empty_file.py)",
   "tests": []
 }

--- a/test/example-syntax-error/results.json
+++ b/test/example-syntax-error/results.json
@@ -1,6 +1,6 @@
 {
   "version": 3,
   "status": "error",
-  "message": "  File \"./test/example-syntax-error/example_syntax_error.py\", line 3\n    def hello();\n               ^\nSyntaxError: invalid syntax",
+  "message": " .usr.local.lib.python3.9.site-packages._pytest.python.py:578: in _importtestmodule\n    mod = import_path(self.fspath, mode=importmode)\n.usr.local.lib.python3.9.site-packages._pytest.pathlib.py:524: in import_path\n    importlib.import_module(module_name)\n.usr.local.lib.python3.9.importlib.__init__.py:127: in import_module\n    return _bootstrap._gcd_import(name[level:], package, level)\n<frozen importlib._bootstrap>:1030: in _gcd_import\n    ???\n<frozen importlib._bootstrap>:1007: in _find_and_load\n    ???\n<frozen importlib._bootstrap>:986: in _find_and_load_unlocked\n    ???\n<frozen importlib._bootstrap>:680: in _load_unlocked\n    ???\n.usr.local.lib.python3.9.site-packages._pytest.assertion.rewrite.py:170: in exec_module\n    exec(co, module.__dict__)\n.solution.example_syntax_error_test.py:4: in <module>\n    from example_syntax_error import hello\nE     File \".solution.example_syntax_error.py\", line 3\nE       def hello();\nE                  ^\nE   SyntaxError: invalid syntax",
   "tests": []
 }


### PR DESCRIPTION
In `__init__.py`:

-  Changed level on `err.chain()` 
-  Altered/cleaned error report message to omit `_pytest.nodes.Collector.CollectError:`, as it may confuse students who see the output in the web UI.