### PR TITLE
[Issues 66 & 85] Fixes for import error/subtest Truncation & stdout Collection for Failing Tests

### DIFF
--- a/test/example-all-fail-tasks-and-subtests/example_all_fail_tasks_and_subtests_test.py
+++ b/test/example-all-fail-tasks-and-subtests/example_all_fail_tasks_and_subtests_test.py
@@ -11,23 +11,21 @@ class ExampleAllFailTest(unittest.TestCase):
     def test_hello(self):
         input_data = [15, 23, 33, 39]
         result_data = [("Hello, World!", param) for param in input_data]
-        number_of_variants = range(1, len(input_data) + 1)
 
-        for variant, param, result in zip(number_of_variants, input_data, result_data):
+        for variant, (param, result) in enumerate(zip(input_data, result_data), start=1):
+            failure_msg=f'Expected: {result} but got something else instead.'
             with self.subTest(f"variation #{variant}", param=param, result=result):
-                self.assertEqual(hello(param), result,
-                                 msg=f'Expected: {result} but got something else instead.')
+                self.assertEqual(hello(param), result, msg=failure_msg)
 
     @pytest.mark.task(taskno=1)
     def test_abc(self):
         input_data = ['frog', 'fish', 'coconut', 'pineapple', 'carrot', 'cucumber', 'grass', 'tree']
         result_data = [("Hello, World!", param) for param in input_data]
-        number_of_variants = range(1, len(input_data) + 1)
 
-        for variant, param, result in zip(number_of_variants, input_data, result_data):
+        for variant, (param, result) in enumerate(zip(input_data, result_data), start=1):
+            failure_msg=f'Expected: {result} but got something else instead.'
             with self.subTest(f"variation #{variant}", param=param, result=result):
-                self.assertEqual(hello(param), result,
-                                 msg=f'Expected: {result} but got something else instead.')
+                self.assertEqual(hello(param), result, msg=failure_msg)
 
 
 class ExampleAllFailOtherTest(unittest.TestCase):
@@ -36,24 +34,18 @@ class ExampleAllFailOtherTest(unittest.TestCase):
     def test_dummy(self):
         input_data = ['frog', 'fish', 'coconut', 'pineapple', 'carrot', 'cucumber', 'grass', 'tree']
         result_data = [("Hello, World!", param) for param in input_data]
-        number_of_variants = range(1, len(input_data) + 1)
 
-        for variant, param, result in zip(number_of_variants, input_data, result_data):
+        for variant, (param, result) in enumerate(zip(input_data, result_data), start=1):
+            failure_msg=f'Expected: {result} but got something else instead.'
             with self.subTest(f"variation #{variant}", param=param, result=result):
-                self.assertEqual(hello(param), result,
-                                 msg=f'Expected: {result} but got something else instead.')
+                self.assertEqual(hello(param), result, msg=failure_msg)
 
     @pytest.mark.task(taskno=2)
     def test_hello(self):
         input_data = [1, 2, 5, 10]
         result_data = [("Hello, World!", param) for param in input_data]
-        number_of_variants = range(1, len(input_data) + 1)
 
-        for variant, param, result in zip(number_of_variants, input_data, result_data):
+        for variant, (param, result) in enumerate(zip(input_data, result_data), start=1):
+            failure_msg=f'Expected: {result} but got something else instead.'
             with self.subTest(f"variation #{variant}", param=param, result=result):
-                self.assertEqual(hello(param), result,
-                                 msg=f'Expected: {result} but got something else instead.')
-
-
-if __name__ == "__main__":
-    unittest.main()
+                self.assertEqual(hello(param), result, msg=failure_msg)

--- a/test/example-all-fail-tasks-and-subtests/results.json
+++ b/test/example-all-fail-tasks-and-subtests/results.json
@@ -6,196 +6,196 @@
       "name": "ExampleAllFail > abc",
       "status": "fail",
       "message": "One or more variations of this test failed. Details can be found under each [variant#].",
-      "test_code": "input_data = ['frog', 'fish', 'coconut', 'pineapple', 'carrot', 'cucumber', 'grass', 'tree']\nresult_data = [(\"Hello, World!\", param) for param in input_data]\nnumber_of_variants = range(1, len(input_data) + 1)\n\nfor variant, param, result in zip(number_of_variants, input_data, result_data):\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result,\n                         msg=f'Expected: {result} but got something else instead.')",
+      "test_code": "input_data = ['frog', 'fish', 'coconut', 'pineapple', 'carrot', 'cucumber', 'grass', 'tree']\nresult_data = [(\"Hello, World!\", param) for param in input_data]\n\nfor variant, (param, result) in enumerate(zip(input_data, result_data), start=1):\n    failure_msg=f'Expected: {result} but got something else instead.'\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result, msg=failure_msg)",
       "task_id": 1
     },
     {
       "name": "ExampleAllFail > hello",
       "status": "fail",
       "message": "One or more variations of this test failed. Details can be found under each [variant#].",
-      "test_code": "input_data = [15, 23, 33, 39]\nresult_data = [(\"Hello, World!\", param) for param in input_data]\nnumber_of_variants = range(1, len(input_data) + 1)\n\nfor variant, param, result in zip(number_of_variants, input_data, result_data):\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result,\n                         msg=f'Expected: {result} but got something else instead.')",
+      "test_code": "input_data = [15, 23, 33, 39]\nresult_data = [(\"Hello, World!\", param) for param in input_data]\n\nfor variant, (param, result) in enumerate(zip(input_data, result_data), start=1):\n    failure_msg=f'Expected: {result} but got something else instead.'\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result, msg=failure_msg)",
       "task_id": 1
     },
     {
       "name": "ExampleAllFail > hello [variation #1] (param=15, result=('Hello, World!', 15))",
       "status": "fail",
       "message": "AssertionError: 'Goodbye!' != ('Hello, World!', 15) : Expected: ('Hello, World!', 15) but got something else instead.",
-      "test_code": "input_data = [15, 23, 33, 39]\nresult_data = [(\"Hello, World!\", param) for param in input_data]\nnumber_of_variants = range(1, len(input_data) + 1)\n\nfor variant, param, result in zip(number_of_variants, input_data, result_data):\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result,\n                         msg=f'Expected: {result} but got something else instead.')",
+      "test_code": "input_data = [15, 23, 33, 39]\nresult_data = [(\"Hello, World!\", param) for param in input_data]\n\nfor variant, (param, result) in enumerate(zip(input_data, result_data), start=1):\n    failure_msg=f'Expected: {result} but got something else instead.'\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result, msg=failure_msg)",
       "task_id": 1
     },
     {
       "name": "ExampleAllFail > hello [variation #2] (param=23, result=('Hello, World!', 23))",
       "status": "fail",
       "message": "AssertionError: 'Goodbye!' != ('Hello, World!', 23) : Expected: ('Hello, World!', 23) but got something else instead.",
-      "test_code": "input_data = [15, 23, 33, 39]\nresult_data = [(\"Hello, World!\", param) for param in input_data]\nnumber_of_variants = range(1, len(input_data) + 1)\n\nfor variant, param, result in zip(number_of_variants, input_data, result_data):\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result,\n                         msg=f'Expected: {result} but got something else instead.')",
+      "test_code": "input_data = [15, 23, 33, 39]\nresult_data = [(\"Hello, World!\", param) for param in input_data]\n\nfor variant, (param, result) in enumerate(zip(input_data, result_data), start=1):\n    failure_msg=f'Expected: {result} but got something else instead.'\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result, msg=failure_msg)",
       "task_id": 1
     },
     {
       "name": "ExampleAllFail > hello [variation #3] (param=33, result=('Hello, World!', 33))",
       "status": "fail",
       "message": "AssertionError: 'Goodbye!' != ('Hello, World!', 33) : Expected: ('Hello, World!', 33) but got something else instead.",
-      "test_code": "input_data = [15, 23, 33, 39]\nresult_data = [(\"Hello, World!\", param) for param in input_data]\nnumber_of_variants = range(1, len(input_data) + 1)\n\nfor variant, param, result in zip(number_of_variants, input_data, result_data):\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result,\n                         msg=f'Expected: {result} but got something else instead.')",
+      "test_code": "input_data = [15, 23, 33, 39]\nresult_data = [(\"Hello, World!\", param) for param in input_data]\n\nfor variant, (param, result) in enumerate(zip(input_data, result_data), start=1):\n    failure_msg=f'Expected: {result} but got something else instead.'\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result, msg=failure_msg)",
       "task_id": 1
     },
     {
       "name": "ExampleAllFail > hello [variation #4] (param=39, result=('Hello, World!', 39))",
       "status": "fail",
       "message": "AssertionError: 'Goodbye!' != ('Hello, World!', 39) : Expected: ('Hello, World!', 39) but got something else instead.",
-      "test_code": "input_data = [15, 23, 33, 39]\nresult_data = [(\"Hello, World!\", param) for param in input_data]\nnumber_of_variants = range(1, len(input_data) + 1)\n\nfor variant, param, result in zip(number_of_variants, input_data, result_data):\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result,\n                         msg=f'Expected: {result} but got something else instead.')",
+      "test_code": "input_data = [15, 23, 33, 39]\nresult_data = [(\"Hello, World!\", param) for param in input_data]\n\nfor variant, (param, result) in enumerate(zip(input_data, result_data), start=1):\n    failure_msg=f'Expected: {result} but got something else instead.'\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result, msg=failure_msg)",
       "task_id": 1
     },
     {
       "name": "ExampleAllFail > abc [variation #1] (param='frog', result=('Hello, World!', 'frog'))",
       "status": "fail",
       "message": "AssertionError: 'Goodbye!' != ('Hello, World!', 'frog') : Expected: ('Hello, World!', 'frog') but got something else instead.",
-      "test_code": "input_data = ['frog', 'fish', 'coconut', 'pineapple', 'carrot', 'cucumber', 'grass', 'tree']\nresult_data = [(\"Hello, World!\", param) for param in input_data]\nnumber_of_variants = range(1, len(input_data) + 1)\n\nfor variant, param, result in zip(number_of_variants, input_data, result_data):\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result,\n                         msg=f'Expected: {result} but got something else instead.')",
+      "test_code": "input_data = ['frog', 'fish', 'coconut', 'pineapple', 'carrot', 'cucumber', 'grass', 'tree']\nresult_data = [(\"Hello, World!\", param) for param in input_data]\n\nfor variant, (param, result) in enumerate(zip(input_data, result_data), start=1):\n    failure_msg=f'Expected: {result} but got something else instead.'\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result, msg=failure_msg)",
       "task_id": 1
     },
     {
       "name": "ExampleAllFail > abc [variation #2] (param='fish', result=('Hello, World!', 'fish'))",
       "status": "fail",
       "message": "AssertionError: 'Goodbye!' != ('Hello, World!', 'fish') : Expected: ('Hello, World!', 'fish') but got something else instead.",
-      "test_code": "input_data = ['frog', 'fish', 'coconut', 'pineapple', 'carrot', 'cucumber', 'grass', 'tree']\nresult_data = [(\"Hello, World!\", param) for param in input_data]\nnumber_of_variants = range(1, len(input_data) + 1)\n\nfor variant, param, result in zip(number_of_variants, input_data, result_data):\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result,\n                         msg=f'Expected: {result} but got something else instead.')",
+      "test_code": "input_data = ['frog', 'fish', 'coconut', 'pineapple', 'carrot', 'cucumber', 'grass', 'tree']\nresult_data = [(\"Hello, World!\", param) for param in input_data]\n\nfor variant, (param, result) in enumerate(zip(input_data, result_data), start=1):\n    failure_msg=f'Expected: {result} but got something else instead.'\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result, msg=failure_msg)",
       "task_id": 1
     },
     {
       "name": "ExampleAllFail > abc [variation #3] (param='coconut', result=('Hello, World!', 'coconut'))",
       "status": "fail",
       "message": "AssertionError: 'Goodbye!' != ('Hello, World!', 'coconut') : Expected: ('Hello, World!', 'coconut') but got something else instead.",
-      "test_code": "input_data = ['frog', 'fish', 'coconut', 'pineapple', 'carrot', 'cucumber', 'grass', 'tree']\nresult_data = [(\"Hello, World!\", param) for param in input_data]\nnumber_of_variants = range(1, len(input_data) + 1)\n\nfor variant, param, result in zip(number_of_variants, input_data, result_data):\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result,\n                         msg=f'Expected: {result} but got something else instead.')",
+      "test_code": "input_data = ['frog', 'fish', 'coconut', 'pineapple', 'carrot', 'cucumber', 'grass', 'tree']\nresult_data = [(\"Hello, World!\", param) for param in input_data]\n\nfor variant, (param, result) in enumerate(zip(input_data, result_data), start=1):\n    failure_msg=f'Expected: {result} but got something else instead.'\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result, msg=failure_msg)",
       "task_id": 1
     },
     {
       "name": "ExampleAllFail > abc [variation #4] (param='pineapple', result=('Hello, World!', 'pineapple'))",
       "status": "fail",
       "message": "AssertionError: 'Goodbye!' != ('Hello, World!', 'pineapple') : Expected: ('Hello, World!', 'pineapple') but got something else instead.",
-      "test_code": "input_data = ['frog', 'fish', 'coconut', 'pineapple', 'carrot', 'cucumber', 'grass', 'tree']\nresult_data = [(\"Hello, World!\", param) for param in input_data]\nnumber_of_variants = range(1, len(input_data) + 1)\n\nfor variant, param, result in zip(number_of_variants, input_data, result_data):\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result,\n                         msg=f'Expected: {result} but got something else instead.')",
+      "test_code": "input_data = ['frog', 'fish', 'coconut', 'pineapple', 'carrot', 'cucumber', 'grass', 'tree']\nresult_data = [(\"Hello, World!\", param) for param in input_data]\n\nfor variant, (param, result) in enumerate(zip(input_data, result_data), start=1):\n    failure_msg=f'Expected: {result} but got something else instead.'\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result, msg=failure_msg)",
       "task_id": 1
     },
     {
       "name": "ExampleAllFail > abc [variation #5] (param='carrot', result=('Hello, World!', 'carrot'))",
       "status": "fail",
       "message": "AssertionError: 'Goodbye!' != ('Hello, World!', 'carrot') : Expected: ('Hello, World!', 'carrot') but got something else instead.",
-      "test_code": "input_data = ['frog', 'fish', 'coconut', 'pineapple', 'carrot', 'cucumber', 'grass', 'tree']\nresult_data = [(\"Hello, World!\", param) for param in input_data]\nnumber_of_variants = range(1, len(input_data) + 1)\n\nfor variant, param, result in zip(number_of_variants, input_data, result_data):\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result,\n                         msg=f'Expected: {result} but got something else instead.')",
+      "test_code": "input_data = ['frog', 'fish', 'coconut', 'pineapple', 'carrot', 'cucumber', 'grass', 'tree']\nresult_data = [(\"Hello, World!\", param) for param in input_data]\n\nfor variant, (param, result) in enumerate(zip(input_data, result_data), start=1):\n    failure_msg=f'Expected: {result} but got something else instead.'\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result, msg=failure_msg)",
       "task_id": 1
     },
     {
       "name": "ExampleAllFail > abc [variation #6] (param='cucumber', result=('Hello, World!', 'cucumber'))",
       "status": "fail",
       "message": "AssertionError: 'Goodbye!' != ('Hello, World!', 'cucumber') : Expected: ('Hello, World!', 'cucumber') but got something else instead.",
-      "test_code": "input_data = ['frog', 'fish', 'coconut', 'pineapple', 'carrot', 'cucumber', 'grass', 'tree']\nresult_data = [(\"Hello, World!\", param) for param in input_data]\nnumber_of_variants = range(1, len(input_data) + 1)\n\nfor variant, param, result in zip(number_of_variants, input_data, result_data):\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result,\n                         msg=f'Expected: {result} but got something else instead.')",
+      "test_code": "input_data = ['frog', 'fish', 'coconut', 'pineapple', 'carrot', 'cucumber', 'grass', 'tree']\nresult_data = [(\"Hello, World!\", param) for param in input_data]\n\nfor variant, (param, result) in enumerate(zip(input_data, result_data), start=1):\n    failure_msg=f'Expected: {result} but got something else instead.'\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result, msg=failure_msg)",
       "task_id": 1
     },
     {
       "name": "ExampleAllFail > abc [variation #7] (param='grass', result=('Hello, World!', 'grass'))",
       "status": "fail",
       "message": "AssertionError: 'Goodbye!' != ('Hello, World!', 'grass') : Expected: ('Hello, World!', 'grass') but got something else instead.",
-      "test_code": "input_data = ['frog', 'fish', 'coconut', 'pineapple', 'carrot', 'cucumber', 'grass', 'tree']\nresult_data = [(\"Hello, World!\", param) for param in input_data]\nnumber_of_variants = range(1, len(input_data) + 1)\n\nfor variant, param, result in zip(number_of_variants, input_data, result_data):\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result,\n                         msg=f'Expected: {result} but got something else instead.')",
+      "test_code": "input_data = ['frog', 'fish', 'coconut', 'pineapple', 'carrot', 'cucumber', 'grass', 'tree']\nresult_data = [(\"Hello, World!\", param) for param in input_data]\n\nfor variant, (param, result) in enumerate(zip(input_data, result_data), start=1):\n    failure_msg=f'Expected: {result} but got something else instead.'\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result, msg=failure_msg)",
       "task_id": 1
     },
     {
       "name": "ExampleAllFail > abc [variation #8] (param='tree', result=('Hello, World!', 'tree'))",
       "status": "fail",
       "message": "AssertionError: 'Goodbye!' != ('Hello, World!', 'tree') : Expected: ('Hello, World!', 'tree') but got something else instead.",
-      "test_code": "input_data = ['frog', 'fish', 'coconut', 'pineapple', 'carrot', 'cucumber', 'grass', 'tree']\nresult_data = [(\"Hello, World!\", param) for param in input_data]\nnumber_of_variants = range(1, len(input_data) + 1)\n\nfor variant, param, result in zip(number_of_variants, input_data, result_data):\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result,\n                         msg=f'Expected: {result} but got something else instead.')",
+      "test_code": "input_data = ['frog', 'fish', 'coconut', 'pineapple', 'carrot', 'cucumber', 'grass', 'tree']\nresult_data = [(\"Hello, World!\", param) for param in input_data]\n\nfor variant, (param, result) in enumerate(zip(input_data, result_data), start=1):\n    failure_msg=f'Expected: {result} but got something else instead.'\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result, msg=failure_msg)",
       "task_id": 1
     },
     {
       "name": "ExampleAllFailOther > dummy",
       "status": "fail",
       "message": "One or more variations of this test failed. Details can be found under each [variant#].",
-      "test_code": "input_data = ['frog', 'fish', 'coconut', 'pineapple', 'carrot', 'cucumber', 'grass', 'tree']\nresult_data = [(\"Hello, World!\", param) for param in input_data]\nnumber_of_variants = range(1, len(input_data) + 1)\n\nfor variant, param, result in zip(number_of_variants, input_data, result_data):\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result,\n                         msg=f'Expected: {result} but got something else instead.')",
+      "test_code": "input_data = ['frog', 'fish', 'coconut', 'pineapple', 'carrot', 'cucumber', 'grass', 'tree']\nresult_data = [(\"Hello, World!\", param) for param in input_data]\n\nfor variant, (param, result) in enumerate(zip(input_data, result_data), start=1):\n    failure_msg=f'Expected: {result} but got something else instead.'\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result, msg=failure_msg)",
       "task_id": 2
     },
     {
       "name": "ExampleAllFailOther > hello",
       "status": "fail",
       "message": "One or more variations of this test failed. Details can be found under each [variant#].",
-      "test_code": "input_data = [1, 2, 5, 10]\nresult_data = [(\"Hello, World!\", param) for param in input_data]\nnumber_of_variants = range(1, len(input_data) + 1)\n\nfor variant, param, result in zip(number_of_variants, input_data, result_data):\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result,\n                         msg=f'Expected: {result} but got something else instead.')",
+      "test_code": "input_data = [1, 2, 5, 10]\nresult_data = [(\"Hello, World!\", param) for param in input_data]\n\nfor variant, (param, result) in enumerate(zip(input_data, result_data), start=1):\n    failure_msg=f'Expected: {result} but got something else instead.'\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result, msg=failure_msg)",
       "task_id": 2
     },
     {
       "name": "ExampleAllFailOther > dummy [variation #1] (param='frog', result=('Hello, World!', 'frog'))",
       "status": "fail",
       "message": "AssertionError: 'Goodbye!' != ('Hello, World!', 'frog') : Expected: ('Hello, World!', 'frog') but got something else instead.",
-      "test_code": "input_data = ['frog', 'fish', 'coconut', 'pineapple', 'carrot', 'cucumber', 'grass', 'tree']\nresult_data = [(\"Hello, World!\", param) for param in input_data]\nnumber_of_variants = range(1, len(input_data) + 1)\n\nfor variant, param, result in zip(number_of_variants, input_data, result_data):\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result,\n                         msg=f'Expected: {result} but got something else instead.')",
+      "test_code": "input_data = ['frog', 'fish', 'coconut', 'pineapple', 'carrot', 'cucumber', 'grass', 'tree']\nresult_data = [(\"Hello, World!\", param) for param in input_data]\n\nfor variant, (param, result) in enumerate(zip(input_data, result_data), start=1):\n    failure_msg=f'Expected: {result} but got something else instead.'\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result, msg=failure_msg)",
       "task_id": 2
     },
     {
       "name": "ExampleAllFailOther > dummy [variation #2] (param='fish', result=('Hello, World!', 'fish'))",
       "status": "fail",
       "message": "AssertionError: 'Goodbye!' != ('Hello, World!', 'fish') : Expected: ('Hello, World!', 'fish') but got something else instead.",
-      "test_code": "input_data = ['frog', 'fish', 'coconut', 'pineapple', 'carrot', 'cucumber', 'grass', 'tree']\nresult_data = [(\"Hello, World!\", param) for param in input_data]\nnumber_of_variants = range(1, len(input_data) + 1)\n\nfor variant, param, result in zip(number_of_variants, input_data, result_data):\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result,\n                         msg=f'Expected: {result} but got something else instead.')",
+      "test_code": "input_data = ['frog', 'fish', 'coconut', 'pineapple', 'carrot', 'cucumber', 'grass', 'tree']\nresult_data = [(\"Hello, World!\", param) for param in input_data]\n\nfor variant, (param, result) in enumerate(zip(input_data, result_data), start=1):\n    failure_msg=f'Expected: {result} but got something else instead.'\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result, msg=failure_msg)",
       "task_id": 2
     },
     {
       "name": "ExampleAllFailOther > dummy [variation #3] (param='coconut', result=('Hello, World!', 'coconut'))",
       "status": "fail",
       "message": "AssertionError: 'Goodbye!' != ('Hello, World!', 'coconut') : Expected: ('Hello, World!', 'coconut') but got something else instead.",
-      "test_code": "input_data = ['frog', 'fish', 'coconut', 'pineapple', 'carrot', 'cucumber', 'grass', 'tree']\nresult_data = [(\"Hello, World!\", param) for param in input_data]\nnumber_of_variants = range(1, len(input_data) + 1)\n\nfor variant, param, result in zip(number_of_variants, input_data, result_data):\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result,\n                         msg=f'Expected: {result} but got something else instead.')",
+      "test_code": "input_data = ['frog', 'fish', 'coconut', 'pineapple', 'carrot', 'cucumber', 'grass', 'tree']\nresult_data = [(\"Hello, World!\", param) for param in input_data]\n\nfor variant, (param, result) in enumerate(zip(input_data, result_data), start=1):\n    failure_msg=f'Expected: {result} but got something else instead.'\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result, msg=failure_msg)",
       "task_id": 2
     },
     {
       "name": "ExampleAllFailOther > dummy [variation #4] (param='pineapple', result=('Hello, World!', 'pineapple'))",
       "status": "fail",
       "message": "AssertionError: 'Goodbye!' != ('Hello, World!', 'pineapple') : Expected: ('Hello, World!', 'pineapple') but got something else instead.",
-      "test_code": "input_data = ['frog', 'fish', 'coconut', 'pineapple', 'carrot', 'cucumber', 'grass', 'tree']\nresult_data = [(\"Hello, World!\", param) for param in input_data]\nnumber_of_variants = range(1, len(input_data) + 1)\n\nfor variant, param, result in zip(number_of_variants, input_data, result_data):\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result,\n                         msg=f'Expected: {result} but got something else instead.')",
+      "test_code": "input_data = ['frog', 'fish', 'coconut', 'pineapple', 'carrot', 'cucumber', 'grass', 'tree']\nresult_data = [(\"Hello, World!\", param) for param in input_data]\n\nfor variant, (param, result) in enumerate(zip(input_data, result_data), start=1):\n    failure_msg=f'Expected: {result} but got something else instead.'\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result, msg=failure_msg)",
       "task_id": 2
     },
     {
       "name": "ExampleAllFailOther > dummy [variation #5] (param='carrot', result=('Hello, World!', 'carrot'))",
       "status": "fail",
       "message": "AssertionError: 'Goodbye!' != ('Hello, World!', 'carrot') : Expected: ('Hello, World!', 'carrot') but got something else instead.",
-      "test_code": "input_data = ['frog', 'fish', 'coconut', 'pineapple', 'carrot', 'cucumber', 'grass', 'tree']\nresult_data = [(\"Hello, World!\", param) for param in input_data]\nnumber_of_variants = range(1, len(input_data) + 1)\n\nfor variant, param, result in zip(number_of_variants, input_data, result_data):\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result,\n                         msg=f'Expected: {result} but got something else instead.')",
+      "test_code": "input_data = ['frog', 'fish', 'coconut', 'pineapple', 'carrot', 'cucumber', 'grass', 'tree']\nresult_data = [(\"Hello, World!\", param) for param in input_data]\n\nfor variant, (param, result) in enumerate(zip(input_data, result_data), start=1):\n    failure_msg=f'Expected: {result} but got something else instead.'\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result, msg=failure_msg)",
       "task_id": 2
     },
     {
       "name": "ExampleAllFailOther > dummy [variation #6] (param='cucumber', result=('Hello, World!', 'cucumber'))",
       "status": "fail",
       "message": "AssertionError: 'Goodbye!' != ('Hello, World!', 'cucumber') : Expected: ('Hello, World!', 'cucumber') but got something else instead.",
-      "test_code": "input_data = ['frog', 'fish', 'coconut', 'pineapple', 'carrot', 'cucumber', 'grass', 'tree']\nresult_data = [(\"Hello, World!\", param) for param in input_data]\nnumber_of_variants = range(1, len(input_data) + 1)\n\nfor variant, param, result in zip(number_of_variants, input_data, result_data):\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result,\n                         msg=f'Expected: {result} but got something else instead.')",
+      "test_code": "input_data = ['frog', 'fish', 'coconut', 'pineapple', 'carrot', 'cucumber', 'grass', 'tree']\nresult_data = [(\"Hello, World!\", param) for param in input_data]\n\nfor variant, (param, result) in enumerate(zip(input_data, result_data), start=1):\n    failure_msg=f'Expected: {result} but got something else instead.'\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result, msg=failure_msg)",
       "task_id": 2
     },
     {
       "name": "ExampleAllFailOther > dummy [variation #7] (param='grass', result=('Hello, World!', 'grass'))",
       "status": "fail",
       "message": "AssertionError: 'Goodbye!' != ('Hello, World!', 'grass') : Expected: ('Hello, World!', 'grass') but got something else instead.",
-      "test_code": "input_data = ['frog', 'fish', 'coconut', 'pineapple', 'carrot', 'cucumber', 'grass', 'tree']\nresult_data = [(\"Hello, World!\", param) for param in input_data]\nnumber_of_variants = range(1, len(input_data) + 1)\n\nfor variant, param, result in zip(number_of_variants, input_data, result_data):\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result,\n                         msg=f'Expected: {result} but got something else instead.')",
+      "test_code": "input_data = ['frog', 'fish', 'coconut', 'pineapple', 'carrot', 'cucumber', 'grass', 'tree']\nresult_data = [(\"Hello, World!\", param) for param in input_data]\n\nfor variant, (param, result) in enumerate(zip(input_data, result_data), start=1):\n    failure_msg=f'Expected: {result} but got something else instead.'\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result, msg=failure_msg)",
       "task_id": 2
     },
     {
       "name": "ExampleAllFailOther > dummy [variation #8] (param='tree', result=('Hello, World!', 'tree'))",
       "status": "fail",
       "message": "AssertionError: 'Goodbye!' != ('Hello, World!', 'tree') : Expected: ('Hello, World!', 'tree') but got something else instead.",
-      "test_code": "input_data = ['frog', 'fish', 'coconut', 'pineapple', 'carrot', 'cucumber', 'grass', 'tree']\nresult_data = [(\"Hello, World!\", param) for param in input_data]\nnumber_of_variants = range(1, len(input_data) + 1)\n\nfor variant, param, result in zip(number_of_variants, input_data, result_data):\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result,\n                         msg=f'Expected: {result} but got something else instead.')",
+      "test_code": "input_data = ['frog', 'fish', 'coconut', 'pineapple', 'carrot', 'cucumber', 'grass', 'tree']\nresult_data = [(\"Hello, World!\", param) for param in input_data]\n\nfor variant, (param, result) in enumerate(zip(input_data, result_data), start=1):\n    failure_msg=f'Expected: {result} but got something else instead.'\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result, msg=failure_msg)",
       "task_id": 2
     },
     {
       "name": "ExampleAllFailOther > hello [variation #1] (param=1, result=('Hello, World!', 1))",
       "status": "fail",
       "message": "AssertionError: 'Goodbye!' != ('Hello, World!', 1) : Expected: ('Hello, World!', 1) but got something else instead.",
-      "test_code": "input_data = [1, 2, 5, 10]\nresult_data = [(\"Hello, World!\", param) for param in input_data]\nnumber_of_variants = range(1, len(input_data) + 1)\n\nfor variant, param, result in zip(number_of_variants, input_data, result_data):\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result,\n                         msg=f'Expected: {result} but got something else instead.')",
+      "test_code": "input_data = [1, 2, 5, 10]\nresult_data = [(\"Hello, World!\", param) for param in input_data]\n\nfor variant, (param, result) in enumerate(zip(input_data, result_data), start=1):\n    failure_msg=f'Expected: {result} but got something else instead.'\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result, msg=failure_msg)",
       "task_id": 2
     },
     {
       "name": "ExampleAllFailOther > hello [variation #2] (param=2, result=('Hello, World!', 2))",
       "status": "fail",
       "message": "AssertionError: 'Goodbye!' != ('Hello, World!', 2) : Expected: ('Hello, World!', 2) but got something else instead.",
-      "test_code": "input_data = [1, 2, 5, 10]\nresult_data = [(\"Hello, World!\", param) for param in input_data]\nnumber_of_variants = range(1, len(input_data) + 1)\n\nfor variant, param, result in zip(number_of_variants, input_data, result_data):\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result,\n                         msg=f'Expected: {result} but got something else instead.')",
+      "test_code": "input_data = [1, 2, 5, 10]\nresult_data = [(\"Hello, World!\", param) for param in input_data]\n\nfor variant, (param, result) in enumerate(zip(input_data, result_data), start=1):\n    failure_msg=f'Expected: {result} but got something else instead.'\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result, msg=failure_msg)",
       "task_id": 2
     },
     {
       "name": "ExampleAllFailOther > hello [variation #3] (param=5, result=('Hello, World!', 5))",
       "status": "fail",
       "message": "AssertionError: 'Goodbye!' != ('Hello, World!', 5) : Expected: ('Hello, World!', 5) but got something else instead.",
-      "test_code": "input_data = [1, 2, 5, 10]\nresult_data = [(\"Hello, World!\", param) for param in input_data]\nnumber_of_variants = range(1, len(input_data) + 1)\n\nfor variant, param, result in zip(number_of_variants, input_data, result_data):\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result,\n                         msg=f'Expected: {result} but got something else instead.')",
+      "test_code": "input_data = [1, 2, 5, 10]\nresult_data = [(\"Hello, World!\", param) for param in input_data]\n\nfor variant, (param, result) in enumerate(zip(input_data, result_data), start=1):\n    failure_msg=f'Expected: {result} but got something else instead.'\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result, msg=failure_msg)",
       "task_id": 2
     },
     {
       "name": "ExampleAllFailOther > hello [variation #4] (param=10, result=('Hello, World!', 10))",
       "status": "fail",
       "message": "AssertionError: 'Goodbye!' != ('Hello, World!', 10) : Expected: ('Hello, World!', 10) but got something else instead.",
-      "test_code": "input_data = [1, 2, 5, 10]\nresult_data = [(\"Hello, World!\", param) for param in input_data]\nnumber_of_variants = range(1, len(input_data) + 1)\n\nfor variant, param, result in zip(number_of_variants, input_data, result_data):\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result,\n                         msg=f'Expected: {result} but got something else instead.')",
+      "test_code": "input_data = [1, 2, 5, 10]\nresult_data = [(\"Hello, World!\", param) for param in input_data]\n\nfor variant, (param, result) in enumerate(zip(input_data, result_data), start=1):\n    failure_msg=f'Expected: {result} but got something else instead.'\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result, msg=failure_msg)",
       "task_id": 2
     }
   ]

--- a/test/example-has-stdout-and-tasks-and-subtests/results.json
+++ b/test/example-has-stdout-and-tasks-and-subtests/results.json
@@ -1,0 +1,6 @@
+{
+  "version": 3,
+  "status": "error",
+  "message": "Unexpected ExitCode.USAGE_ERROR: check logs for details",
+  "tests": []
+}

--- a/test/example-has-stdout-tasks-and-subtests/results.json
+++ b/test/example-has-stdout-tasks-and-subtests/results.json
@@ -7,7 +7,8 @@
       "status": "fail",
       "message": "One or more variations of this test failed. Details can be found under each [variant#].",
       "test_code": "input_data = [1, 2, 5, 10, 15, 23, 33, 39]\nresult_data = [(\"Hello, World!\", param) for param in input_data]\nnumber_of_variants = range(1, len(input_data) + 1)\n\nfor variant, param, result in zip(number_of_variants, input_data, result_data):\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result,\n                         msg=f'Expected: {result} but got something else instead.')",
-      "task_id": 1
+      "task_id": 1,
+      "output": "Hello, World! 1\nHello, World! 2\nHello, World! 5\nHello, World! 10\nHello, World! 15\nHello, World! 23\nHello, World! 33\nHello, World! 39"
     },
     {
       "name": "ExampleHasStdout > hello [variation #1] (param=1, result=('Hello, World!', 1))",
@@ -70,7 +71,8 @@
       "status": "fail",
       "message": "One or more variations of this test failed. Details can be found under each [variant#].",
       "test_code": "input_data = ['frog', 'fish', 'coconut', 'pineapple', 'carrot', 'cucumber', 'grass', 'tree']\nresult_data = [(\"Hello, World!\", param) for param in input_data]\nnumber_of_variants = range(1, len(input_data) + 1)\n\nfor variant, param, result in zip(number_of_variants, input_data, result_data):\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result,\n                         msg=f'Expected: {result} but got something else instead.')",
-      "task_id": 2
+      "task_id": 2,
+      "output": "Hello, World! frog\nHello, World! fish\nHello, World! coconut\nHello, World! pineapple\nHello, World! carrot\nHello, World! cucumber\nHello, World! grass\nHello, World! tree"
     },
     {
       "name": "ExampleHasStdout > abc [variation #1] (param='frog', result=('Hello, World!', 'frog'))",
@@ -141,7 +143,8 @@
       "status": "fail",
       "message": "One or more variations of this test failed. Details can be found under each [variant#].",
       "test_code": "input_data = ['frog', 'fish', 'coconut', 'pineapple', 'carrot', 'cucumber', 'grass', 'tree']\nresult_data = [(\"Hello, World!\", param) for param in input_data]\nnumber_of_variants = range(1, len(input_data) + 1)\n\nfor variant, param, result in zip(number_of_variants, input_data, result_data):\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result,\n                         msg=f'Expected: {result} but got something else instead.')",
-      "task_id": 4
+      "task_id": 4,
+      "output": "Hello, World! frog\nHello, World! fish\nHello, World! coconut\nHello, World! pineapple\nHello, World! carrot\nHello, World! cucumber\nHello, World! grass\nHello, World! tree"
     },
     {
       "name": "ExampleHasStdoutOther > dummy [variation #1] (param='frog', result=('Hello, World!', 'frog'))",
@@ -204,7 +207,8 @@
       "status": "fail",
       "message": "One or more variations of this test failed. Details can be found under each [variant#].",
       "test_code": "input_data = [1, 2, 5, 10, 15, 23, 33, 39]\nresult_data = [(\"Hello, World!\", param) for param in input_data]\nnumber_of_variants = range(1, len(input_data) + 1)\n\nfor variant, param, result in zip(number_of_variants, input_data, result_data):\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result,\n                         msg=f'Expected: {result} but got something else instead.')",
-      "task_id": 5
+      "task_id": 5,
+      "output": "Hello, World! 1\nHello, World! 2\nHello, World! 5\nHello, World! 10\nHello, World! 15\nHello, World! 23\nHello, World! 33\nHello, World! 39"
     },
     {
       "name": "ExampleHasStdoutOther > hello [variation #1] (param=1, result=('Hello, World!', 1))",

--- a/test/example-partial-failure-with-subtests/example_partial_failure_with_subtests_test.py
+++ b/test/example-partial-failure-with-subtests/example_partial_failure_with_subtests_test.py
@@ -11,9 +11,8 @@ class ExamplePartialFailureWithSubtestsTest(unittest.TestCase):
     def test_hello(self):
         input_data = [1, 2, 5, 10]
         result_data = [("Hello, World!", param) for param in input_data]
-        number_of_variants = range(1, len(input_data) + 1)
 
-        for variant, param, result in zip(number_of_variants, input_data, result_data):
+        for variant, (param, result) in enumerate(zip(input_data, result_data), start=1):
             with self.subTest(f"variation #{variant}", param=param, result=result):
                 self.assertEqual(hello(param), result,
                                  msg=f'Expected: {result} but got something else instead.')
@@ -22,9 +21,8 @@ class ExamplePartialFailureWithSubtestsTest(unittest.TestCase):
     def test_abc(self):
         input_data = ['frog', 'fish', 'coconut', 'pineapple', 'carrot', 'cucumber', 'grass', 'tree']
         result_data = [("Hello, World!", param) for param in input_data]
-        number_of_variants = range(1, len(input_data) + 1)
 
-        for variant, param, result in zip(number_of_variants, input_data, result_data):
+        for variant, (param, result) in enumerate(zip(input_data, result_data), start=1):
             with self.subTest(f"variation #{variant}", param=param, result=result):
                 self.assertEqual(hello(param), result,
                                  msg=f'Expected: {result} but got something else instead.')
@@ -35,9 +33,8 @@ class ExamplePartialFailureWithSubtestsOtherTest(unittest.TestCase):
     def test_dummy(self):
         input_data = ['frog', 'fish', 'coconut', 'pineapple', 'carrot', 'cucumber', 'grass', 'tree']
         result_data = [("Hello, World!", param) for param in input_data]
-        number_of_variants = range(1, len(input_data) + 1)
 
-        for variant, param, result in zip(number_of_variants, input_data, result_data):
+        for variant, (param, result) in enumerate(zip(input_data, result_data), start=1):
             with self.subTest(f"variation #{variant}", param=param, result=result):
                 self.assertEqual(hello(param), result,
                                  msg=f'Expected: {result} but got something else instead.')
@@ -47,13 +44,8 @@ class ExamplePartialFailureWithSubtestsOtherTest(unittest.TestCase):
     def test_hello(self):
         input_data = [15, 23, 33, 39]
         result_data = [("Hello, World!", param) for param in input_data]
-        number_of_variants = range(1, len(input_data) + 1)
 
-        for variant, param, result in zip(number_of_variants, input_data, result_data):
+        for variant, (param, result) in enumerate(zip(input_data, result_data), start=1):
             with self.subTest(f"variation #{variant}", param=param, result=result):
                 self.assertEqual(hello(param), result,
                                  msg=f'Expected: {result} but got something else instead.')
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/test/example-partial-failure-with-subtests/results.json
+++ b/test/example-partial-failure-with-subtests/results.json
@@ -5,83 +5,83 @@
     {
       "name": "ExamplePartialFailureWithSubtests > abc",
       "status": "pass",
-      "test_code": "input_data = ['frog', 'fish', 'coconut', 'pineapple', 'carrot', 'cucumber', 'grass', 'tree']\nresult_data = [(\"Hello, World!\", param) for param in input_data]\nnumber_of_variants = range(1, len(input_data) + 1)\n\nfor variant, param, result in zip(number_of_variants, input_data, result_data):\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result,\n                         msg=f'Expected: {result} but got something else instead.')",
+      "test_code": "input_data = ['frog', 'fish', 'coconut', 'pineapple', 'carrot', 'cucumber', 'grass', 'tree']\nresult_data = [(\"Hello, World!\", param) for param in input_data]\n\nfor variant, (param, result) in enumerate(zip(input_data, result_data), start=1):\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result,\n                         msg=f'Expected: {result} but got something else instead.')",
       "task_id": 1
     },
     {
       "name": "ExamplePartialFailureWithSubtests > hello",
       "status": "fail",
       "message": "One or more variations of this test failed. Details can be found under each [variant#].",
-      "test_code": "input_data = [1, 2, 5, 10]\nresult_data = [(\"Hello, World!\", param) for param in input_data]\nnumber_of_variants = range(1, len(input_data) + 1)\n\nfor variant, param, result in zip(number_of_variants, input_data, result_data):\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result,\n                         msg=f'Expected: {result} but got something else instead.')",
+      "test_code": "input_data = [1, 2, 5, 10]\nresult_data = [(\"Hello, World!\", param) for param in input_data]\n\nfor variant, (param, result) in enumerate(zip(input_data, result_data), start=1):\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result,\n                         msg=f'Expected: {result} but got something else instead.')",
       "task_id": 1
     },
     {
       "name": "ExamplePartialFailureWithSubtests > hello [variation #1] (param=1, result=('Hello, World!', 1))",
       "status": "fail",
       "message": "AssertionError: 'Hello, World!' != ('Hello, World!', 1) : Expected: ('Hello, World!', 1) but got something else instead.",
-      "test_code": "input_data = [1, 2, 5, 10]\nresult_data = [(\"Hello, World!\", param) for param in input_data]\nnumber_of_variants = range(1, len(input_data) + 1)\n\nfor variant, param, result in zip(number_of_variants, input_data, result_data):\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result,\n                         msg=f'Expected: {result} but got something else instead.')",
+      "test_code": "input_data = [1, 2, 5, 10]\nresult_data = [(\"Hello, World!\", param) for param in input_data]\n\nfor variant, (param, result) in enumerate(zip(input_data, result_data), start=1):\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result,\n                         msg=f'Expected: {result} but got something else instead.')",
       "task_id": 1
     },
     {
       "name": "ExamplePartialFailureWithSubtests > hello [variation #2] (param=2, result=('Hello, World!', 2))",
       "status": "fail",
       "message": "AssertionError: 'Hello, World!' != ('Hello, World!', 2) : Expected: ('Hello, World!', 2) but got something else instead.",
-      "test_code": "input_data = [1, 2, 5, 10]\nresult_data = [(\"Hello, World!\", param) for param in input_data]\nnumber_of_variants = range(1, len(input_data) + 1)\n\nfor variant, param, result in zip(number_of_variants, input_data, result_data):\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result,\n                         msg=f'Expected: {result} but got something else instead.')",
+      "test_code": "input_data = [1, 2, 5, 10]\nresult_data = [(\"Hello, World!\", param) for param in input_data]\n\nfor variant, (param, result) in enumerate(zip(input_data, result_data), start=1):\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result,\n                         msg=f'Expected: {result} but got something else instead.')",
       "task_id": 1
     },
     {
       "name": "ExamplePartialFailureWithSubtests > hello [variation #3] (param=5, result=('Hello, World!', 5))",
       "status": "fail",
       "message": "AssertionError: 'Hello, World!' != ('Hello, World!', 5) : Expected: ('Hello, World!', 5) but got something else instead.",
-      "test_code": "input_data = [1, 2, 5, 10]\nresult_data = [(\"Hello, World!\", param) for param in input_data]\nnumber_of_variants = range(1, len(input_data) + 1)\n\nfor variant, param, result in zip(number_of_variants, input_data, result_data):\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result,\n                         msg=f'Expected: {result} but got something else instead.')",
+      "test_code": "input_data = [1, 2, 5, 10]\nresult_data = [(\"Hello, World!\", param) for param in input_data]\n\nfor variant, (param, result) in enumerate(zip(input_data, result_data), start=1):\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result,\n                         msg=f'Expected: {result} but got something else instead.')",
       "task_id": 1
     },
     {
       "name": "ExamplePartialFailureWithSubtests > hello [variation #4] (param=10, result=('Hello, World!', 10))",
       "status": "fail",
       "message": "AssertionError: 'Hello, World!' != ('Hello, World!', 10) : Expected: ('Hello, World!', 10) but got something else instead.",
-      "test_code": "input_data = [1, 2, 5, 10]\nresult_data = [(\"Hello, World!\", param) for param in input_data]\nnumber_of_variants = range(1, len(input_data) + 1)\n\nfor variant, param, result in zip(number_of_variants, input_data, result_data):\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result,\n                         msg=f'Expected: {result} but got something else instead.')",
+      "test_code": "input_data = [1, 2, 5, 10]\nresult_data = [(\"Hello, World!\", param) for param in input_data]\n\nfor variant, (param, result) in enumerate(zip(input_data, result_data), start=1):\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result,\n                         msg=f'Expected: {result} but got something else instead.')",
       "task_id": 1
     },
     {
       "name": "ExamplePartialFailureWithSubtestsOther > dummy",
       "status": "pass",
-      "test_code": "input_data = ['frog', 'fish', 'coconut', 'pineapple', 'carrot', 'cucumber', 'grass', 'tree']\nresult_data = [(\"Hello, World!\", param) for param in input_data]\nnumber_of_variants = range(1, len(input_data) + 1)\n\nfor variant, param, result in zip(number_of_variants, input_data, result_data):\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result,\n                         msg=f'Expected: {result} but got something else instead.')",
+      "test_code": "input_data = ['frog', 'fish', 'coconut', 'pineapple', 'carrot', 'cucumber', 'grass', 'tree']\nresult_data = [(\"Hello, World!\", param) for param in input_data]\n\nfor variant, (param, result) in enumerate(zip(input_data, result_data), start=1):\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result,\n                         msg=f'Expected: {result} but got something else instead.')",
       "task_id": 2
     },
     {
       "name": "ExamplePartialFailureWithSubtestsOther > hello",
       "status": "fail",
       "message": "One or more variations of this test failed. Details can be found under each [variant#].",
-      "test_code": "input_data = [15, 23, 33, 39]\nresult_data = [(\"Hello, World!\", param) for param in input_data]\nnumber_of_variants = range(1, len(input_data) + 1)\n\nfor variant, param, result in zip(number_of_variants, input_data, result_data):\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result,\n                         msg=f'Expected: {result} but got something else instead.')",
+      "test_code": "input_data = [15, 23, 33, 39]\nresult_data = [(\"Hello, World!\", param) for param in input_data]\n\nfor variant, (param, result) in enumerate(zip(input_data, result_data), start=1):\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result,\n                         msg=f'Expected: {result} but got something else instead.')",
       "task_id": 2
     },
     {
       "name": "ExamplePartialFailureWithSubtestsOther > hello [variation #1] (param=15, result=('Hello, World!', 15))",
       "status": "fail",
       "message": "AssertionError: 'Hello, World!' != ('Hello, World!', 15) : Expected: ('Hello, World!', 15) but got something else instead.",
-      "test_code": "input_data = [15, 23, 33, 39]\nresult_data = [(\"Hello, World!\", param) for param in input_data]\nnumber_of_variants = range(1, len(input_data) + 1)\n\nfor variant, param, result in zip(number_of_variants, input_data, result_data):\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result,\n                         msg=f'Expected: {result} but got something else instead.')",
+      "test_code": "input_data = [15, 23, 33, 39]\nresult_data = [(\"Hello, World!\", param) for param in input_data]\n\nfor variant, (param, result) in enumerate(zip(input_data, result_data), start=1):\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result,\n                         msg=f'Expected: {result} but got something else instead.')",
       "task_id": 2
     },
     {
       "name": "ExamplePartialFailureWithSubtestsOther > hello [variation #2] (param=23, result=('Hello, World!', 23))",
       "status": "fail",
       "message": "AssertionError: 'Hello, World!' != ('Hello, World!', 23) : Expected: ('Hello, World!', 23) but got something else instead.",
-      "test_code": "input_data = [15, 23, 33, 39]\nresult_data = [(\"Hello, World!\", param) for param in input_data]\nnumber_of_variants = range(1, len(input_data) + 1)\n\nfor variant, param, result in zip(number_of_variants, input_data, result_data):\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result,\n                         msg=f'Expected: {result} but got something else instead.')",
+      "test_code": "input_data = [15, 23, 33, 39]\nresult_data = [(\"Hello, World!\", param) for param in input_data]\n\nfor variant, (param, result) in enumerate(zip(input_data, result_data), start=1):\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result,\n                         msg=f'Expected: {result} but got something else instead.')",
       "task_id": 2
     },
     {
       "name": "ExamplePartialFailureWithSubtestsOther > hello [variation #3] (param=33, result=('Hello, World!', 33))",
       "status": "fail",
       "message": "AssertionError: 'Hello, World!' != ('Hello, World!', 33) : Expected: ('Hello, World!', 33) but got something else instead.",
-      "test_code": "input_data = [15, 23, 33, 39]\nresult_data = [(\"Hello, World!\", param) for param in input_data]\nnumber_of_variants = range(1, len(input_data) + 1)\n\nfor variant, param, result in zip(number_of_variants, input_data, result_data):\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result,\n                         msg=f'Expected: {result} but got something else instead.')",
+      "test_code": "input_data = [15, 23, 33, 39]\nresult_data = [(\"Hello, World!\", param) for param in input_data]\n\nfor variant, (param, result) in enumerate(zip(input_data, result_data), start=1):\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result,\n                         msg=f'Expected: {result} but got something else instead.')",
       "task_id": 2
     },
     {
       "name": "ExamplePartialFailureWithSubtestsOther > hello [variation #4] (param=39, result=('Hello, World!', 39))",
       "status": "fail",
       "message": "AssertionError: 'Hello, World!' != ('Hello, World!', 39) : Expected: ('Hello, World!', 39) but got something else instead.",
-      "test_code": "input_data = [15, 23, 33, 39]\nresult_data = [(\"Hello, World!\", param) for param in input_data]\nnumber_of_variants = range(1, len(input_data) + 1)\n\nfor variant, param, result in zip(number_of_variants, input_data, result_data):\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result,\n                         msg=f'Expected: {result} but got something else instead.')",
+      "test_code": "input_data = [15, 23, 33, 39]\nresult_data = [(\"Hello, World!\", param) for param in input_data]\n\nfor variant, (param, result) in enumerate(zip(input_data, result_data), start=1):\n    with self.subTest(f\"variation #{variant}\", param=param, result=result):\n        self.assertEqual(hello(param), result,\n                         msg=f'Expected: {result} but got something else instead.')",
       "task_id": 2
     }
   ]


### PR DESCRIPTION
Fixes issues #66 and #85 

* Added code to collect `stdout` for tests that have failed (previous code was only collecting stdout for passed tests)
* Added code to check for `importError` AND `Lasagna` for error chain truncation, so that Lasagna Subtests run correctly
* Recreated and re-generated golden test files for `stdout` and some `subtest` scenarios.