### PR TITLE
fix: specify version of pytest

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 # cmccandless: Breaking changes in pytest 5.4.0
 # Changelog: https://docs.pytest.org/en/stable/changelog.html#pytest-5-4-0-2020-03-12
-pytest >= 6.0.0
+pytest ~= 6.2.5
 pytest-subtests>=0.4.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 # cmccandless: Breaking changes in pytest 5.4.0
 # Changelog: https://docs.pytest.org/en/stable/changelog.html#pytest-5-4-0-2020-03-12
 pytest ~= 6.2.5
-pytest-subtests>=0.4.0
+pytest-subtests~=0.5.0


### PR DESCRIPTION
The module Pytest recently released new version 7.0.0 and changed dependencies.
So we temporarily keep version compatible with 6.

Related to: https://github.com/exercism/python/pull/2892