### PR TITLE
added tomli to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@
 # Changelog: https://docs.pytest.org/en/stable/changelog.html#pytest-5-4-0-2020-03-12
 pytest ~= 6.2.5
 pytest-subtests~=0.5.0
+tomli


### PR DESCRIPTION
Hoping this fixes the broken CI in the main repo.  Black has been upgraded to use the `tomli` library instead of the `toml` library, and that breaks things with the test generation and validation scripts, since they use `black` to format their output, and then use the test runner to validate the tests.

Additionally, see [this issue](https://github.com/psf/black/issues/2964) for another black issue that required updating black to version 22.3.0.