### PR TITLE
[Hello World] Added Hello World to ImportError Message Extraction 

### DIFF
--- a/runner/__init__.py
+++ b/runner/__init__.py
@@ -146,7 +146,7 @@ class ResultsReporter:
             err = excinfo.getrepr(style="no", abspath=False)
 
             # trim off full traceback for first exercise to be friendlier and clearer
-            if 'lasagna' in node.name and 'ImportError' in str(err.chain[0]):
+            if ('lasagna' in node.name or 'hello world') and 'ImportError' in str(err.chain[0]):
                 trace = err.chain[-2][0]
             else:
                 trace = err.chain[-1][0]

--- a/runner/__init__.py
+++ b/runner/__init__.py
@@ -145,8 +145,8 @@ class ResultsReporter:
             excinfo = call.excinfo
             err = excinfo.getrepr(style="no", abspath=False)
 
-            # trim off full traceback for first exercise to be friendlier and clearer
-            if ('lasagna' in node.name or 'hello world') and 'ImportError' in str(err.chain[0]):
+            # trim off full traceback for first two exercises to be friendlier and clearer
+            if ('lasagna' in node.name or 'hello_world' in node.name) and 'ImportError' in str(err.chain[0]):
                 trace = err.chain[-2][0]
             else:
                 trace = err.chain[-1][0]

--- a/test/example-hello-world-function-import-error/example_hello_world_function_import_error.py
+++ b/test/example-hello-world-function-import-error/example_hello_world_function_import_error.py
@@ -1,0 +1,2 @@
+print("Hello, World!")
+

--- a/test/example-hello-world-function-import-error/example_hello_world_function_import_error_test.py
+++ b/test/example-hello-world-function-import-error/example_hello_world_function_import_error_test.py
@@ -1,0 +1,26 @@
+import unittest
+
+try:
+    from hello_world import (
+        hello,
+    )
+
+except ImportError as import_fail:
+    message = import_fail.args[0].split("(", maxsplit=1)
+    item_name = import_fail.args[0].split()[3]
+
+    item_name = item_name[:-1] + "()'"
+
+    # pylint: disable=raise-missing-from
+    raise ImportError(
+        "\n\nMISSING FUNCTION --> In your 'hello_world.py' file, we can not find or import the"
+        f" function named {item_name}. \nThe tests for this first exercise expect a function that"
+        f' returns the string "Hello, World!"'
+        f'\n\nDid you use print("Hello, World!") instead?'
+    ) from None
+
+
+class HelloWorldTest(unittest.TestCase):
+    def test_say_hi(self):
+        msg = "\n\nThis test expects a return of the string 'Hello, World!' \nDid you use print('Hello, World!') by mistake?"
+        self.assertEqual(hello(), "Hello, World!", msg=msg)

--- a/test/example-hello-world-function-import-error/results.json
+++ b/test/example-hello-world-function-import-error/results.json
@@ -1,0 +1,6 @@
+{
+  "version": 3,
+  "status": "error",
+  "message": "ImportError: \n\nMISSING FUNCTION --> In your 'hello_world.py' file, we can not find or import the function named 'hello_world()'. \nThe tests for this first exercise expect a function that returns the string \"Hello, World!\"\n\nDid you use print(\"Hello, World!\") instead?",
+  "tests": []
+}


### PR DESCRIPTION
Decided that we should do for `Hello World` what we did for `Lasagna` (see #110 for some details).

Added `hello_world` to the function starting on line **140**:

```python

    def pytest_exception_interact(self, node, call, report):
        """
        Catch the last exception handled in case the test run itself errors.
        """
        if report.outcome == "failed":
            excinfo = call.excinfo
            err = excinfo.getrepr(style="no", abspath=False)

            # trim off full traceback for first two exercises to be friendlier and clearer
            if ('lasagna' in node.name or 'hello_world' in node.name) and 'ImportError' in str(err.chain[0]):
                trace = err.chain[-2][0]
            else:
                trace = err.chain[-1][0]

            crash = err.chain[0][1]
            self.last_err = self._make_message(trace, crash)

```

Now they will see the following in the UI (once the [test file changes in the content repo](https://github.com/exercism/python/pull/3347) are merged):

```python
ImportError: 
   
MISSING FUNCTION --> In your 'hello_world.py' file, we can not find or import the function named hello().
The tests for this first exercise expect a function that returns the string "Hello, World!"
 
Did you use print("Hello, World!") instead?
```

Also added a test for this exercise/scenario.